### PR TITLE
Endpoint API for creating a new driver

### DIFF
--- a/app/controllers/api/v1/drivers.rb
+++ b/app/controllers/api/v1/drivers.rb
@@ -6,54 +6,80 @@ module Api
       helpers SessionHelpers
 
 
-      before do
-        error!('Unauthorized', 401) unless require_login!
-      end
-
-
-
-    # desc "Return all drivers"
-    # get "/drivers/all", root: :driver do
-    #   Driver.all
-    # end
-
-
-
-      desc "Return a driver with a given id"
+      desc "Create a Driver"
       params do
-        # requires :id, type: String, desc: "ID of driver"
+        requires :email , type:String
+        requires :password, type:String
+        requires :first_name, type: String
+        requires :last_name, type: String
+        requires :phone, type: String
+        requires :organization_id, type: Integer
       end
-      get "drivers", root: :driver do
-        driver = current_driver
-        location_ids = LocationRelationship.where(driver_id: current_driver.id)
-        locations = []
-        location_ids.each do |id|
-          locations.push(Location.where(id: id))
+      post "drivers(json)" do
+        driver = Driver.new({organization_id: params[:organization_id], email: params[:email],password: params[:password],first_name: params[:first_name],last_name: params[:last_name],phone: params[:phone]})
+        if driver.save
+          status 200
+          render json: driver
+        #Return bad request error code and error
+        else
+          status 400
+          render json: driver.errors
+
         end
-        return driver
-        #render json: {"driver": driver, "location": locations}
       end
 
 
-      desc "Update a driver with a given id"
-      params do
-      end
-      put "drivers" do
-        driver = current_driver
-        driver.update(first_name: params[:first_name], last_name: params[:last_name], phone: params[:phone],
-                      email: params[:email], car_make: params[:car_make], car_model: params[:car_model],
-                      car_color: params[:car_color], radius: params[:radius], is_active: params[:is_active])
-        return current_driver
-      end
+
+      namespace do
+        before do
+          error!('Unauthorized', 401) unless require_login!
+        end
 
 
-      desc "Delete a driver with a given id"
-      params do
-      end
-      delete "drivers" do
-        driver = current_driver
-        if driver.destroy != nil
-          return { sucess:true }
+
+      # desc "Return all drivers"
+      # get "/drivers/all", root: :driver do
+      #   Driver.all
+      # end
+
+
+
+        desc "Return a driver with a given id"
+        params do
+          # requires :id, type: String, desc: "ID of driver"
+        end
+        get "drivers", root: :driver do
+          driver = current_driver
+          location_ids = LocationRelationship.where(driver_id: current_driver.id)
+          locations = []
+          location_ids.each do |id|
+            locations.push(Location.where(id: id))
+        end
+          return driver
+          #render json: {"driver": driver, "location": locations}
+        end
+
+
+        desc "Update a driver with a given id"
+        params do
+        end
+        put "drivers" do
+          driver = current_driver
+          driver.update(first_name: params[:first_name], last_name: params[:last_name], phone: params[:phone],
+                        email: params[:email], car_make: params[:car_make], car_model: params[:car_model],
+                        car_color: params[:car_color], radius: params[:radius], is_active: params[:is_active])
+          return current_driver
+        end
+
+
+        desc "Delete a driver with a given id"
+        params do
+        end
+        delete "drivers" do
+          driver = current_driver
+          if driver.destroy != nil
+            return { sucess:true }
+          end
         end
       end
     end


### PR DESCRIPTION
Added in endpoint call to create new driver, also surrounded other actions in the namespace to make then have to authenticate , whereas the new driver does not have to be authenticated. 