### PR TITLE
Seperate vehicle info

### DIFF
--- a/app/models/driver.rb
+++ b/app/models/driver.rb
@@ -7,6 +7,7 @@ class Driver < ApplicationRecord
   belongs_to :organization
   has_many :rides
   has_many :schedule_windows
+  has_many :vehicles
 
 
   devise :database_authenticatable, :registerable,

--- a/app/models/vehicle.rb
+++ b/app/models/vehicle.rb
@@ -1,0 +1,2 @@
+class Vehicle < ApplicationRecord
+end

--- a/app/models/vehicle.rb
+++ b/app/models/vehicle.rb
@@ -1,2 +1,3 @@
 class Vehicle < ApplicationRecord
+  belongs_to :driver
 end

--- a/db/migrate/20190603152447_remove_car_info.rb
+++ b/db/migrate/20190603152447_remove_car_info.rb
@@ -1,0 +1,13 @@
+class RemoveCarInfo < ActiveRecord::Migration[5.2]
+  def change
+    remove_column  :drivers, :car_make
+    remove_column  :drivers, :car_model
+    remove_column  :drivers, :car_color
+    remove_column  :drivers, :car_year
+    remove_column  :drivers, :car_plate
+    remove_column  :drivers, :insurance_provider
+    remove_column  :drivers, :insurance_start
+    remove_column  :drivers, :insurance_stop
+    remove_column  :drivers, :application_state
+  end
+end

--- a/db/migrate/20190603152948_create_vehicles.rb
+++ b/db/migrate/20190603152948_create_vehicles.rb
@@ -1,0 +1,17 @@
+class CreateVehicles < ActiveRecord::Migration[5.2]
+  def change
+    create_table :vehicles do |t|
+      t.belongs_to :driver
+      t.string :car_make
+      t.string :car_model
+      t.string :car_color
+      t.integer :car_year
+      t.string :car_plate
+      t.integer :seat_belt_num
+      t.string :insurance_provider
+      t.date :insurance_start
+      t.date :insurance_stop
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_28_160539) do
+ActiveRecord::Schema.define(version: 2019_06_03_152447) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,9 +20,6 @@ ActiveRecord::Schema.define(version: 2019_05_28_160539) do
     t.string "first_name"
     t.string "last_name"
     t.string "phone"
-    t.string "car_make"
-    t.string "car_model"
-    t.string "car_color"
     t.integer "radius", default: 50
     t.boolean "is_active", default: true
     t.string "email", default: "", null: false
@@ -34,12 +31,7 @@ ActiveRecord::Schema.define(version: 2019_05_28_160539) do
     t.datetime "updated_at", null: false
     t.string "auth_token"
     t.datetime "token_created_at"
-    t.integer "car_year"
-    t.string "car_plate"
-    t.string "insurance_provider"
-    t.datetime "insurance_start"
-    t.datetime "insurance_stop"
-    t.string "application_state"
+    t.boolean "background_check"
     t.index ["auth_token", "token_created_at"], name: "index_drivers_on_auth_token_and_token_created_at"
     t.index ["organization_id"], name: "index_drivers_on_organization_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_03_152447) do
+ActiveRecord::Schema.define(version: 2019_06_03_152948) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -159,6 +159,22 @@ ActiveRecord::Schema.define(version: 2019_06_03_152447) do
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+  end
+
+  create_table "vehicles", force: :cascade do |t|
+    t.bigint "driver_id"
+    t.string "car_make"
+    t.string "car_model"
+    t.string "car_color"
+    t.integer "car_year"
+    t.string "car_plate"
+    t.integer "seat_belt_num"
+    t.string "insurance_provider"
+    t.date "insurance_start"
+    t.date "insurance_stop"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["driver_id"], name: "index_vehicles_on_driver_id"
   end
 
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -12,10 +12,17 @@ Organization.create(name: "Durham Rescue Mission", email: "drm@gmail.com", passw
 Organization.create(name: "Urban Ministries of Durham",  email: "umd@gmail.com", password: "password", password_confirmation: "password")
 
 
-Driver.create(organization_id: "1", first_name: "Teddy", last_name: "Ruby", phone: "4086948508", email: "ejr25@duke.edu", car_make: "Toyota", car_model: "Tacoma", car_color: "Silver", password: "password", password_confirmation: "password")
-Driver.create(organization_id: "1", first_name: "John", last_name: "Smith", phone: "4362484055", email: "j.smith@gmail.com", car_make: "Toyota", car_model: "Camry", car_color: "Blue", password: "password", password_confirmation: "password")
-Driver.create(organization_id: "1", first_name: "Katie", last_name: "Jones", phone: "92986948508", email: "katie@duke.edu", car_make: "Honda", car_model: "Civic", car_color: "Black", password: "password", password_confirmation: "password")
-Driver.create(organization_id: "2", first_name: "Sarah", last_name: "Kim", phone: "4029348508", email: "Sarah.Kim@yahoo.com", car_make: "Nissan", car_model: "Altima", car_color: "Silver", password: "password", password_confirmation: "password")
+Driver.create(organization_id: "1", first_name: "Teddy", last_name: "Ruby", phone: "4086948508", email: "ejr25@duke.edu", password: "password", password_confirmation: "password")
+Driver.create(organization_id: "1", first_name: "John", last_name: "Smith", phone: "4362484055", email: "j.smith@gmail.com", password: "password", password_confirmation: "password")
+Driver.create(organization_id: "1", first_name: "Katie", last_name: "Jones", phone: "92986948508", email: "katie@duke.edu", password: "password", password_confirmation: "password")
+Driver.create(organization_id: "2", first_name: "Sarah", last_name: "Kim", phone: "4029348508", email: "Sarah.Kim@yahoo.com", password: "password", password_confirmation: "password")
+
+Vehicle.create(driver_id: "1", car_make: "Toyota", car_model: "Tacoma", car_color: "Silver", car_year: "2010", car_plate: "ZQWOPQ", seat_belt_num: "4", insurance_provider: "Geico", insurance_start: "2019-02-19", insurance_stop: "2020-02-19" )
+Vehicle.create(driver_id: "2",car_make: "Toyota", car_model: "Camry", car_color: "Blue", car_year: "2010", car_plate: "ZQWOPQ", seat_belt_num: "4", insurance_provider: "Geico", insurance_start: "2019-01-19", insurance_stop: "2020-01-19")
+Vehicle.create(driver_id: "3", car_make: "Honda", car_model: "Civic", car_color: "Black", car_year: "2010", car_plate: "ZQWOPQ", seat_belt_num: "4", insurance_provider: "Geico", insurance_start: "2019-03-19", insurance_stop: "2020-03-19")
+Vehicle.create(driver_id: "4", car_make: "Nissan", car_model: "Altima", car_color: "Silver", car_year: "2010", car_plate: "ZQWOPQ", seat_belt_num: "4", insurance_provider: "Geico", insurance_start: "2019-05-19", insurance_stop: "2020-05-19")
+
+
 
 Rider.create(organization_id: "1", first_name: "Katelyn", last_name: "Splint" , phone: "9293842930", email: "ks@duke.edu", password: "password", password_confirmation: "password")
 Rider.create(organization_id: "1", first_name: "James", last_name: "Cage" , phone: "3292842339",  email: "cage@gmail.com", password: "password", password_confirmation: "password")

--- a/test/fixtures/vehicles.yml
+++ b/test/fixtures/vehicles.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/vehicle_test.rb
+++ b/test/models/vehicle_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class VehicleTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
I separated out vehicle information (such as car_model etc.) from the driver model. This will require modification to any piece of the project that talks about vehicle information because the call will be slightly different. This change was enacted because driver could potentially have more than one vehicle. 