### PR TITLE
Organization api endpoint

### DIFF
--- a/app/controllers/api/v1/base.rb
+++ b/app/controllers/api/v1/base.rb
@@ -11,6 +11,7 @@ module Api
       mount Api::V1::Locations
       mount Api::V1::Sessions
       mount Api::V1::Vehicles
+      mount Api::V1::Organizations
 
       add_swagger_documentation(
           api_version: "v1",

--- a/app/controllers/api/v1/drivers.rb
+++ b/app/controllers/api/v1/drivers.rb
@@ -23,7 +23,6 @@ module Api
         driver = Driver.new
         driver.attributes= (params[:driver])
         if driver.save
-          status 200
           render driver: driver
         #Return bad request error code and error
         else

--- a/app/controllers/api/v1/organizations.rb
+++ b/app/controllers/api/v1/organizations.rb
@@ -6,8 +6,8 @@ module Api
       helpers SessionHelpers
 
 
-
-        desc "Return a organizations of current  driver"
+      #Request to see all organizations and information about organizations
+        desc "Return all organizations "
         params do
 
         end

--- a/app/controllers/api/v1/organizations.rb
+++ b/app/controllers/api/v1/organizations.rb
@@ -1,0 +1,23 @@
+module Api
+  module V1
+    class Organizations < Grape::API
+      include Api::V1::Defaults
+
+      helpers SessionHelpers
+
+
+
+        desc "Return a organizations of current  driver"
+        params do
+
+        end
+        get "organizations", root: :organization do
+        organizations = Organization.all
+        render organizations
+        end
+
+
+
+      end
+    end
+  end

--- a/app/serializers/organization_serializer.rb
+++ b/app/serializers/organization_serializer.rb
@@ -1,0 +1,9 @@
+class OrganizationSerializer < ActiveModel::Serializer
+  ActiveModel::Serializer.config.adapter = :json
+
+  attributes :id, :name, :street, :city, :state, :zip
+
+
+
+
+end

--- a/spec/factories/organization.rb
+++ b/spec/factories/organization.rb
@@ -1,5 +1,9 @@
-FactoryBot.define do 
+FactoryBot.define do
    factory :organization do
-   name {'drivers'}
+   name {'Duke'}
+   street {'200 Front Street'}
+   city {'Durham'}
+   state {'NC'}
+   zip {'27708'}
    end
 end

--- a/spec/requests/drivers_controller_spec.rb
+++ b/spec/requests/drivers_controller_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Api::DriversController, type: :request do
     let!(:organization) { FactoryBot.create(:organization) }
-    let!(:driver) { FactoryBot.create(:driver, organization_id: organization.id) }
+    let!(:driver) { FactoryBot.create(:driver, organization_id: 1) }
     it 'driver login in' do
     post '/api/v1/login', headers: {"ACCEPT" => "application/json" }, params: { email: "v1@sample.com", password: "password" }
 

--- a/spec/requests/drivers_controller_spec.rb
+++ b/spec/requests/drivers_controller_spec.rb
@@ -2,11 +2,11 @@ require 'rails_helper'
 
 RSpec.describe Api::DriversController, type: :request do
     let!(:organization) { FactoryBot.create(:organization) }
-    let!(:driver) { FactoryBot.create(:driver, organization_id: 1) }
+    let!(:driver) { FactoryBot.create(:driver, organization_id: organization.id) }
     it 'driver login in' do
     post '/api/v1/login', headers: {"ACCEPT" => "application/json" }, params: { email: "v1@sample.com", password: "password" }
-       
-       expect(response).to have_http_status(201) 
+
+       expect(response).to have_http_status(201)
         puts response.body
     end
 

--- a/spec/requests/organizations_controller_spec.rb
+++ b/spec/requests/organizations_controller_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe Api::OrganizationsController, type: :request do
+    let!(:organization) { FactoryBot.create(:organization) }
+    let!(:organization1) { FactoryBot.create(:organization, name: 'Chapel Hill Health') }
+    let!(:organization2) { FactoryBot.create(:organization, zip: 27709) }
+
+    it 'driver login in' do
+    get '/api/v1/organizations', headers: {"ACCEPT" => "application/json" }
+
+
+      puts response.body
+      parsed_json = JSON.parse(response.body)
+      expect(parsed_json['organization'][0]['name']).to eq('Duke')
+      expect(parsed_json['organization'][0]['street']).to eq('200 Front Street')
+      expect(parsed_json['organization'][0]['city']).to eq('Durham')
+      expect(parsed_json['organization'][0]['state']).to eq('NC')
+      expect(parsed_json['organization'][0]['zip']).to eq('27708')
+      expect(parsed_json['organization'][1]['name']).to eq('Chapel Hill Health')
+      expect(parsed_json['organization'][2]['zip']).to eq('27709')
+
+    end
+
+end

--- a/spec/requests/organizations_controller_spec.rb
+++ b/spec/requests/organizations_controller_spec.rb
@@ -5,11 +5,13 @@ RSpec.describe Api::OrganizationsController, type: :request do
     let!(:organization1) { FactoryBot.create(:organization, name: 'Chapel Hill Health') }
     let!(:organization2) { FactoryBot.create(:organization, zip: 27709) }
 
-    it 'driver login in' do
+    it 'test output of organization endpoint' do
     get '/api/v1/organizations', headers: {"ACCEPT" => "application/json" }
 
 
-      puts response.body
+      #puts response.body
+      #Checkout out that response is what it should be
+      #Only testing parts I changed on the second and third object
       parsed_json = JSON.parse(response.body)
       expect(parsed_json['organization'][0]['name']).to eq('Duke')
       expect(parsed_json['organization'][0]['street']).to eq('200 Front Street')


### PR DESCRIPTION
Create Organizations api endpoint so you can receive all the organizations to pick from. This includes a test for the organization endpoint to confirm it is functioning correctly. This endpoint is so drivers can pick organization they are signing up for. 