### PR TITLE
 Standardize serializer output to include root name of driver

### DIFF
--- a/app/controllers/api/v1/drivers.rb
+++ b/app/controllers/api/v1/drivers.rb
@@ -23,7 +23,7 @@ module Api
         driver = Driver.new
         driver.attributes= (params[:driver])
         if driver.save
-          render driver: driver
+          render  driver
         #Return bad request error code and error
         else
           status 400
@@ -45,7 +45,7 @@ module Api
         location_ids.each do |id|
           locations.push(Location.where(id: id))
         end
-        render driver: driver
+        render driver
         #render json: {"driver": driver, "location": locations}
       end
 

--- a/app/serializers/driver_serializer.rb
+++ b/app/serializers/driver_serializer.rb
@@ -1,5 +1,5 @@
 class DriverSerializer < ActiveModel::Serializer
-
+  ActiveModelSerializers.config.adapter = :json
   attributes :organization_id, :id, :first_name, :last_name, :phone,
              :email, :radius, :is_active
   has_many :vehicles


### PR DESCRIPTION
Made the serializer include the model type as the root element. Did this to make input and output be the same. Both require the model name then the attributes now. 