### PR TITLE
Failed location test

### DIFF
--- a/app/controllers/api/v1/locations.rb
+++ b/app/controllers/api/v1/locations.rb
@@ -27,7 +27,7 @@ module Api
         driver = current_driver
         location_ids = LocationRelationship.where(driver_id: driver.id).select("location_id")
         locations = Location.where(id: location_ids)
-        locations
+        render locations
       end
 
 

--- a/app/controllers/api/v1/locations.rb
+++ b/app/controllers/api/v1/locations.rb
@@ -25,9 +25,9 @@ module Api
       end
       get "locations" do
         driver = current_driver
-        location_ids = LocationRelationship.where(driver_id: driver.id).ids
+        location_ids = LocationRelationship.where(driver_id: driver.id).select("location_id")
         locations = Location.where(id: location_ids)
-        render locations
+        locations
       end
 
 

--- a/spec/requests/locations_spec.rb
+++ b/spec/requests/locations_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Api::V1::Locations, type: :request do
 
       expect(response).to have_http_status(200)
       parsed_json = JSON.parse(response.body)
-      puts parsed_json
+    
       expect(parsed_json['locations'][0]['street']).to eq('1200 front')
       expect(parsed_json['locations'][0]['city']).to eq('Durham')
       expect(parsed_json['locations'][0]['state']).to eq('NC')

--- a/spec/requests/locations_spec.rb
+++ b/spec/requests/locations_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Api::V1::Locations, type: :request do
 
       expect(response).to have_http_status(200)
       parsed_json = JSON.parse(response.body)
-      #puts parsed_json
+      puts parsed_json
       expect(parsed_json['locations'][0]['street']).to eq('1200 front')
       expect(parsed_json['locations'][0]['city']).to eq('Durham')
       expect(parsed_json['locations'][0]['state']).to eq('NC')


### PR DESCRIPTION
Location logic was finding the ids of the Locationrelationship and putting them into the location query. These two would usually match but not always. So had to tell the query to select the location_id instead. This resolved failed test issues. 