### PR TITLE
Schedule window model tests fix

### DIFF
--- a/app/models/schedule_window.rb
+++ b/app/models/schedule_window.rb
@@ -5,7 +5,7 @@ class ScheduleWindow < ApplicationRecord
   validates :start_time, :end_time, :is_recurring, presence: true
   validates :start_date, :end_date, presence: true, if: :is_recurring?
 
-  validate  :dates_cannot_be_in_the_past
+  # validate  :dates_cannot_be_in_the_past
   validate  :end_time_after_start_time
   validate  :end_date_after_start_date
   validate  :start_date_cannot_be_later_than_start_time
@@ -13,23 +13,24 @@ class ScheduleWindow < ApplicationRecord
 
 # Instance methods
 
-  def dates_cannot_be_in_the_past
-    if start_time < DateTime.now
-        errors.add(:start_time, "cannot be in the past")
-    end
+  # def dates_cannot_be_in_the_past
+  #   # if start_time < DateTime.now
+  #   # # byebug
+  #   #     errors.add(:start_time, "cannot be in the past")
+  #   # end
 
-    if end_time < DateTime.now
-      errors.add(:end_time, "cannot be in the past")
-    end
+  #   if end_time < DateTime.now
+  #     errors.add(:end_time, "cannot be in the past")
+  #   end
 
-    if start_date < Date.today
-      errors.add(:start_date, "cannot be in the past")
-    end
+  #   if start_date < Date.today
+  #     errors.add(:start_date, "cannot be in the past")
+  #   end
 
-    if end_date < Date.today
-      errors.add(:end_date, "cannot be in the past")
-    end
-  end
+  #   if end_date < Date.today
+  #     errors.add(:end_date, "cannot be in the past")
+  #   end
+  # end
 
   def end_time_after_start_time
     if start_time.present? && end_time.present?

--- a/app/models/schedule_window.rb
+++ b/app/models/schedule_window.rb
@@ -5,7 +5,7 @@ class ScheduleWindow < ApplicationRecord
   validates :start_time, :end_time, :is_recurring, presence: true
   validates :start_date, :end_date, presence: true, if: :is_recurring?
 
-  # validate  :dates_cannot_be_in_the_past
+  validate  :dates_cannot_be_in_the_past
   validate  :end_time_after_start_time
   validate  :end_date_after_start_date
   validate  :start_date_cannot_be_later_than_start_time
@@ -13,24 +13,23 @@ class ScheduleWindow < ApplicationRecord
 
 # Instance methods
 
-  # def dates_cannot_be_in_the_past
-  #   # if start_time < DateTime.now
-  #   # # byebug
-  #   #     errors.add(:start_time, "cannot be in the past")
-  #   # end
+  def dates_cannot_be_in_the_past
+    if start_time.present? && start_time < DateTime.now
+        errors.add(:start_time, "cannot be in the past")
+    end
 
-  #   if end_time < DateTime.now
-  #     errors.add(:end_time, "cannot be in the past")
-  #   end
+    if end_time.present? && end_time < DateTime.now
+      errors.add(:end_time, "cannot be in the past")
+    end
 
-  #   if start_date < Date.today
-  #     errors.add(:start_date, "cannot be in the past")
-  #   end
+    if start_date.present? && start_date < Date.today
+      errors.add(:start_date, "cannot be in the past")
+    end
 
-  #   if end_date < Date.today
-  #     errors.add(:end_date, "cannot be in the past")
-  #   end
-  # end
+    if end_date.present? && end_date < Date.today
+      errors.add(:end_date, "cannot be in the past")
+    end
+  end
 
   def end_time_after_start_time
     if start_time.present? && end_time.present?

--- a/spec/factories/schedule_windows.rb
+++ b/spec/factories/schedule_windows.rb
@@ -1,11 +1,18 @@
 FactoryBot.define do
   factory :schedule_window do
-    start_time { Date.today }
-    end_time { Date.today + 8.hours }
+    start_time { DateTime.now }
+    end_time { DateTime.now + 8.hours }
     start_date { Date.today }
     end_date { Date.today + 3.months }
+    is_recurring { false }
 
     driver
     location
   end
 end
+
+# (byebug) start_time
+# Thu, 25 Jul 2019 09:00:00 UTC +00:00
+
+# (byebug) DateTime.now
+# Tue, 30 Jul 2019 15:52:42 -0400

--- a/spec/models/schedule_window_spec.rb
+++ b/spec/models/schedule_window_spec.rb
@@ -45,25 +45,25 @@ RSpec.describe ScheduleWindow, type: :model do
     end
 
     describe 'Cannot be in the past' do
-      xit "should validate that start time cannot be in the past" do
+      it "should validate that start time cannot be in the past" do
         subject.start_time = "2019-07-01"
         subject.valid?  # run validations
         expect(subject.errors[:start_time]).to include('cannot be in the past')
       end
 
-      xit "should validate that end time cannot be in the past" do
+      it "should validate that end time cannot be in the past" do
         subject.end_time = "2019-07-01"
         subject.valid?
         expect(subject.errors[:end_time]).to include('cannot be in the past')
       end
 
-      xit "should validate that start date cannot be in the past" do
+      it "should validate that start date cannot be in the past" do
         subject.start_date = "2019-07-01"
         subject.valid?  # run validations
         expect(subject.errors[:start_date]).to include('cannot be in the past')
       end
 
-      xit "should validate that end date cannot be in the past" do
+      it "should validate that end date cannot be in the past" do
         subject.end_date = "2019-07-01"
         subject.valid?
         expect(subject.errors[:end_date]).to include('cannot be in the past')

--- a/spec/models/schedule_window_spec.rb
+++ b/spec/models/schedule_window_spec.rb
@@ -1,39 +1,40 @@
 require 'rails_helper'
 
 RSpec.describe ScheduleWindow, type: :model do
-    let(:recurring_schedule_window)  { build(:schedule_window, is_recurring: true, start_date: "") }
-    let(:recurring_schedule_window2) { build(:schedule_window, is_recurring: true, end_date: "") }
-    let(:recurring_schedule_window3) { build(:schedule_window, is_recurring: true, start_date: Date.today + 2.days) }
-    let(:recurring_schedule_window4) { build(:schedule_window, is_recurring: true, start_time: Date.today + 10.hours) }
-    let(:recurring_schedule_window5) { build(:schedule_window, is_recurring: true, start_date: Date.today + 4.hours) }
-    let(:recurring_schedule_window6) { build(:schedule_window, is_recurring: true, end_date: Date.today) }
+    let(:recurring_schedule_window) { build(:schedule_window, is_recurring: true, end_date: Date.today - 2.days) }
+    let(:recurring_schedule_window1) { build(:schedule_window, end_time: DateTime.now - 10.hours) }
+    let(:recurring_schedule_window2) { build(:schedule_window, is_recurring: true, start_date: Date.today + 1.day) }
+    let(:recurring_schedule_window3) { build(:schedule_window, is_recurring: true, end_date: Date.today - 4.months) }
 
     describe "Validations" do
       it { should validate_presence_of(:start_time) }
       it { should validate_presence_of(:end_time) }
 
-      it "should validate presence of start date" do
-        expect(recurring_schedule_window.valid?).to be_falsey
+      context "When is_recurring false" do
+        it { should_not validate_presence_of(:start_date) }
+        it { should_not validate_presence_of(:end_date) }
       end
 
-      it "should validate presence of end date" do
-        expect(recurring_schedule_window2.valid?).to be_falsey
+      context "When is_recurring true" do
+        before { allow(subject).to receive(:is_recurring?).and_return(true) }
+        it { should validate_presence_of(:start_date) }
+        it { should validate_presence_of(:end_date) }
       end
 
       it "should validate start date cannot be later than end date" do
-        expect(recurring_schedule_window3.valid?).to be_falsey
+        expect(recurring_schedule_window.valid?).to be_falsey
       end
 
-       it "should validate start time cannot be later than end time" do
-        expect(recurring_schedule_window4.valid?).to be_falsey
+      it "should validate start time cannot be later than end time" do
+        expect(recurring_schedule_window1.valid?).to be_falsey
       end
 
       it "should validate start date cannot be later than start time" do
-        expect(recurring_schedule_window5.valid?).to be_falsey
+        expect(recurring_schedule_window2.valid?).to be_falsey
       end
 
       it "should validate end date cannot be before end time" do
-        expect(recurring_schedule_window6.valid?).to be_falsey
+        expect(recurring_schedule_window3.valid?).to be_falsey
       end
     end
 
@@ -44,25 +45,25 @@ RSpec.describe ScheduleWindow, type: :model do
     end
 
     describe 'Cannot be in the past' do
-      it "should validate that start time cannot be in the past" do
+      xit "should validate that start time cannot be in the past" do
         subject.start_time = "2019-07-01"
         subject.valid?  # run validations
         expect(subject.errors[:start_time]).to include('cannot be in the past')
       end
 
-      it "should validate that end time cannot be in the past" do
+      xit "should validate that end time cannot be in the past" do
         subject.end_time = "2019-07-01"
         subject.valid?
         expect(subject.errors[:end_time]).to include('cannot be in the past')
       end
 
-      it "should validate that start date cannot be in the past" do
+      xit "should validate that start date cannot be in the past" do
         subject.start_date = "2019-07-01"
         subject.valid?  # run validations
         expect(subject.errors[:start_date]).to include('cannot be in the past')
       end
 
-      it "should validate that end date cannot be in the past" do
+      xit "should validate that end date cannot be in the past" do
         subject.end_date = "2019-07-01"
         subject.valid?
         expect(subject.errors[:end_date]).to include('cannot be in the past')
@@ -70,14 +71,14 @@ RSpec.describe ScheduleWindow, type: :model do
     end
 
     describe 'Cannot be overlapped' do
-      it "should validate that start time and end time cannot be overlapped" do
+      it "should validate that end time cannot be before start time" do
         subject.start_time = "2019-07-01 9:00am"
         subject.end_time = "2019-07-01 9:00am"
         subject.valid?  # run validations
         expect(subject.valid?).to be_falsey
       end
 
-      it "should validate that start date and end date cannot be overlapped" do
+      it "should validate that end date cannot be before start date" do
         subject.start_time = "2019-07-01"
         subject.end_time = "2019-07-01"
         subject.valid?  # run validations


### PR DESCRIPTION
- Fixed Schedule Window model tests
- Tests were failing because of the lack of check of fields presence inside the method
- Tests passed only after I added the `field.present?` in the method
@micronix !