### PR TITLE
Update riders without changing passwords

### DIFF
--- a/app/controllers/riders_controller.rb
+++ b/app/controllers/riders_controller.rb
@@ -1,6 +1,8 @@
 class RidersController < ApplicationController
 
   before_action :authenticate_user!
+  before_action :remove_password_params_if_blank, only: [:update]
+
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
   layout "administration"
@@ -126,6 +128,13 @@ class RidersController < ApplicationController
       else
         flash.notice = "Rider does not have any valid tokens"
         redirect_to request.referrer || riders_path
+      end
+    end
+
+    def remove_password_params_if_blank
+      if params[:rider][:password].blank? && params[:rider][:password_confirmation].blank?
+        params[:rider].delete(:password)
+        params[:rider].delete(:password_confirmation)
       end
     end
 end

--- a/app/views/riders/_form.html.erb
+++ b/app/views/riders/_form.html.erb
@@ -54,12 +54,8 @@
 </div>
 
 <div class="row">
-  <div  class="form-group col-md-1 offset-md-1">
-    <%= link_to 'Back', riders_path, class: "btn btn-outline-primary" %>
-  </div>
-
-  <div  class="form-group col-md-1 offset-md-8">
-    <%= form.submit yield(:button_text), class: "btn btn-outline-success my-2 my-sm-0" %>
+  <div  class="form-group col-md-1 offset-md-10">
+    <%= form.submit yield(:button_text), class: "btn btn-sm btn-outline-success" %>
   </div>
 </div>
 


### PR DESCRIPTION
- Added admin ability to update `riders` information without having to change their passwords
     Fix: - Created a private method `remove_password_params_if_blank` and called `before_action` 
              on `:update`
@jrmcgarvey @micronix 

Thank you!