### PR TITLE
Checks on ride endpoints

### DIFF
--- a/app/controllers/api/v1/rides.rb
+++ b/app/controllers/api/v1/rides.rb
@@ -6,170 +6,162 @@ module Api
       helpers SessionHelpers
       helpers RideHelpers
 
-
       before do
         error!('Unauthorized', 401) unless require_login!
       end
 
+      desc "Return all rides"
+      params do
+        optional :start, type: DateTime, desc: "Start date for rides"
+        optional :end, type: String, desc: "End date for rides"
+        optional :status, type: Array[String], desc: "String of status wanted"
+        optional :driver_specific, type: Boolean, desc: "Boolean if rides are driver specific"
+        #Missing functionality for radius feature currently
+        optional :radius, type: Boolean, desc: "Boolean if rides are within radius"
+        optional :location_id, type: Integer, desc: "location to use for radius"
+      end
+      get "rides", root: :rides do
 
-        desc "Return all rides"
-        params do
-          optional :start, type: DateTime, desc: "Start date for rides"
-          optional :end, type: String, desc: "End date for rides"
-          optional :status, type: Array[String], desc: "String of status wanted"
-          optional :driver_specific, type: Boolean, desc: "Boolean if rides are driver specific"
-          #Missing functionality for radius feature currently
-          optional :radius, type: Boolean, desc: "Boolean if rides are within radius"
-          optional :location_id, type: Integer, desc: "location to use for radius" 
+        driver = current_driver
+         if driver.is_active == false
+           status 401
+           return "Not Authorized"
         end
-          get "rides", root: :rides do
-            
-            driver = current_driver
-             if driver.is_active == false
-               status 401
-               return "Not Authorized"
-            end
-            
-            start_time = params[:start]
-            end_time = params[:end]
-            
-            if start_time != nil and end_time != nil
-              rides = Ride.where(organization_id: driver.organization_id).where("pick_up_time >= ?", start_time).where("pick_up_time <= ?", end_time)
-              if rides.length == 0
-                status 404
-                return ""
-              end
-            else 
-              rides = Ride.where(organization_id: driver.organization_id)
-              if rides.length == 0
-                status 404
-                return ""
-              end
-            end
 
-            status = params[:status]
-            # status = Array["pending", "scheduled"]
+        start_time = params[:start]
+        end_time = params[:end]
 
-            if status != nil
-              rides = rides.where(status: status)
-              if rides.length == 0
-                status 404
-                return ""
-              end
-            end
-            if params[:driver_specific] == true
-              rides = rides.where(driver_id: driver.id)
-              if rides.length == 0
-                status 404
-                return ""
-              end
-            end
-
-            # if params[:radius] == true
-            #   rides.each do |ride|
-            #     if check_radius(ride)
-            #   end
-            # end
-            if params[:location_id] != nil 
-              begin 
-                location = Location.find(params[:location_id]) 
-              rescue ActiveRecord::RecordNotFound => e
-                location = nil
-              end
-              if location != nil 
-                if location.latitude != nil && location.longitude != nil
-                  rides_near = rides.select {|ride| ride.is_near?([location.latitude, location.longitude],driver.radius ) }
-                  if rides_near.length > 0
-                    status 200 
-                    return rides_near
-                  else
-                    status 404
-                    return ""
-                  end
-                else 
-                  status 400
-                  return "bad requests"
-                end
-              else 
-                status 400
-                return "bad requested"
-              end
-            end
-            status 200
-            return rides
+        if start_time != nil and end_time != nil
+          rides = Ride.where(organization_id: driver.organization_id).where("pick_up_time >= ?", start_time).where("pick_up_time <= ?", end_time)
+          if rides.length == 0
+            status 404
+            return ""
           end
-
-          desc "Return a ride with given ID"
-          params do
-            requires :ride_id, type: String, desc: "ID of the
-                ride"
+        else
+          rides = Ride.where(organization_id: driver.organization_id)
+          if rides.length == 0
+            status 404
+            return ""
           end
-          
-          get "rides/:ride_id", root: :ride do
-            
-            driver = current_driver
-            if driver.is_active == false
-              status 401
-              return "Not Authorized "
-            end
-            
-            #Only can see rides that the driver own for or have no driver
-            ride = Ride.find(permitted_params[:ride_id])
-            if (ride.driver_id == nil or ride.driver_id ==driver.id)
-              status 201 
-              render ride
+        end
+
+        status = params[:status]
+        # status = Array["pending", "scheduled"]
+
+        if status != nil
+          rides = rides.where(status: status)
+          if rides.length == 0
+            status 404
+            return ""
+          end
+        end
+        if params[:driver_specific] == true
+          rides = rides.where(driver_id: driver.id)
+          if rides.length == 0
+            status 404
+            return ""
+          end
+        end
+
+        # if params[:radius] == true
+        #   rides.each do |ride|
+        #     if check_radius(ride)
+        #   end
+        # end
+        if params[:location_id] != nil
+          begin
+            location = Location.find(params[:location_id])
+          rescue ActiveRecord::RecordNotFound => e
+            location = nil
+          end
+          if location != nil
+            if location.latitude != nil && location.longitude != nil
+              rides_near = rides.select {|ride| ride.is_near?([location.latitude, location.longitude],driver.radius ) }
+              if rides_near.length > 0
+                status 200
+                return rides_near
+              else
+                status 404
+                return ""
+              end
             else
-              status(404)
-              render "Unauthorized"
-            end
-          end
-
-        desc "Accept a ride"
-        params do
-          requires :ride_id, type: String, desc: "ID of the ride"
-        end
-        post "rides/:ride_id/accept" do
-          driver = current_driver
-          if driver.is_active == false
-            status 401
-            return "Not Authorized"
-          end
-            
-          ride = Ride.find(permitted_params[:ride_id])
-          if (ride.driver_id == nil or ride.driver_id == driver.id)
-            if ride.update(driver_id: driver.id, status: "scheduled")
-              status 201
-              render ride
+              status 400
+              return "bad requests"
             end
           else
-            status 401
-            return "Unauthorized"
+            status 400
+            return "bad requested"
           end
         end
+        status 200
+        return rides
+      end
 
+      desc "Return a ride with given ID"
+      params do
+        requires :ride_id, type: String, desc: "ID of the
+            ride"
+      end
 
-        desc "Complete a ride"
-        params do
-          requires :ride_id, type: String, desc: "ID of the ride"
+      get "rides/:ride_id", root: :ride do
+
+        driver = current_driver
+        if driver.is_active == false
+          status 401
+          return "Not Authorized "
         end
-        post "rides/:ride_id/complete" do
-          driver = current_driver
-          if driver.is_active == false
-            status 401
-            return "Not Authorized"
-         end
-          
-          ride = Ride.find(permitted_params[:ride_id])
-          if (ride.driver_id == nil or ride.driver_id ==driver.id)
-            if ride.update(driver_id: driver.id, status: "completed")
-              status 201
-              render ride
-            end
-          else
-             status 401
-             render "Unauthorized"
+
+        #Only can see rides that the driver own for or have no driver
+        ride = Ride.find(permitted_params[:ride_id])
+        if (ride.driver_id == nil or ride.driver_id ==driver.id)
+          status 201
+          render ride
+        else
+          status(404)
+          render "Unauthorized"
+        end
+      end
+
+      # Driver Acceting a ride
+      desc "Accept a ride"
+      params do
+        requires :ride_id, type: String, desc: "ID of the ride"
+      end
+      post "rides/:ride_id/accept" do
+        ride = Ride.find(permitted_params[:ride_id])
+
+        if current_driver.is_active? && ride.driver_id.nil? && ride.status == "approved"
+          ride.update(driver_id: current_driver.id, status: "scheduled")
+          status 201
+          render ride
+        else
+          status 401
+          return "Not Authorized"
+        end
+      end
+
+      desc "Complete a ride"
+      params do
+        requires :ride_id, type: String, desc: "ID of the ride"
+      end
+      post "rides/:ride_id/complete" do
+        driver = current_driver
+        if driver.is_active == false
+          status 401
+          return "Not Authorized"
+       end
+
+        ride = Ride.find(permitted_params[:ride_id])
+        if (ride.driver_id == nil or ride.driver_id ==driver.id)
+          if ride.update(driver_id: driver.id, status: "completed")
+            status 201
+            render ride
           end
+        else
+           status 401
+           render "Unauthorized"
         end
+      end
 
       desc "Cancel a ride"
       params do
@@ -177,7 +169,7 @@ module Api
       end
       post "rides/:ride_id/cancel" do
         driver = current_driver
-        
+
         ride = Ride.find(permitted_params[:ride_id])
         if (ride.driver_id == nil or ride.driver_id ==driver.id)
           if ride.update(driver_id: driver.id, status: "canceled")
@@ -201,7 +193,7 @@ module Api
           status 401
           return "Not Authorized"
         end
-        
+
         ride = Ride.find(permitted_params[:ride_id])
         if (ride.driver_id == nil or ride.driver_id ==driver.id)
           if ride.update(driver_id: driver.id, status: "picking-up")

--- a/app/controllers/api/v1/rides.rb
+++ b/app/controllers/api/v1/rides.rb
@@ -156,22 +156,22 @@ module Api
         end
       end
 
+
+      # Driver cancelling a ride with 'scheduled' status(but it should put ride back to 'approved' status
+      # because other drivers should be able to accept the ride if they want)
       desc "Cancel a ride"
       params do
         requires :ride_id, type: String, desc: "ID of the ride"
       end
       post "rides/:ride_id/cancel" do
-        driver = current_driver
-
         ride = Ride.find(permitted_params[:ride_id])
-        if (ride.driver_id == nil or ride.driver_id ==driver.id)
-          if ride.update(driver_id: driver.id, status: "canceled")
-            status 201
-            render ride
-          end
+        if current_driver.is_active? && ride.status == "scheduled" && ride.driver_id == current_driver.id
+          ride.update(driver_id: nil, status: "approved")
+          status 201
+          render ride
         else
-          status(404)
-          render "Unauthorized"
+          status 401
+          render "Not Authorized"
         end
       end
 

--- a/app/controllers/api/v1/rides.rb
+++ b/app/controllers/api/v1/rides.rb
@@ -198,21 +198,20 @@ module Api
         end
       end
 
-      desc "dropping off driver"
+      # Driver dropping off riders only with picking-up ride status
+      desc "Dropping off a rider"
       params do
         requires :ride_id, type: String, desc: "ID of the ride"
       end
       post "rides/:ride_id/dropping-off" do
-        driver = current_driver
         ride = Ride.find(permitted_params[:ride_id])
-        if (ride.driver_id == nil or ride.driver_id ==driver.id)
-          if ride.update(driver_id: driver.id, status: "dropping-off")
-            status 201
-            render ride
-          end
+        if current_driver.is_active? && ride.status == "picking-up" && ride.driver_id == current_driver.id
+          ride.update(driver_id: current_driver.id, status: "dropping-off")
+          status 201
+          render ride
         else
-          status(404)
-          render "Unauthorized"
+          status 401
+          render "Not Authorized"
         end
       end
     end

--- a/app/controllers/api/v1/rides.rb
+++ b/app/controllers/api/v1/rides.rb
@@ -97,28 +97,19 @@ module Api
         return rides
       end
 
+      # Driver seeing only the rides that they own for or have an 'approved' status
       desc "Return a ride with given ID"
       params do
-        requires :ride_id, type: String, desc: "ID of the
-            ride"
+        requires :ride_id, type: String, desc: "ID of the ride"
       end
-
       get "rides/:ride_id", root: :ride do
-
-        driver = current_driver
-        if driver.is_active == false
-          status 401
-          return "Not Authorized "
-        end
-
-        #Only can see rides that the driver own for or have no driver
         ride = Ride.find(permitted_params[:ride_id])
-        if (ride.driver_id == nil or ride.driver_id ==driver.id)
+        if current_driver.is_active? && ((ride.driver_id == nil && ride.status == "approved") || ride.driver_id == current_driver.id)
           status 201
           render ride
         else
-          status(404)
-          render "Unauthorized"
+          status 401
+          render "Not Authorized"
         end
       end
 

--- a/app/controllers/api/v1/rides.rb
+++ b/app/controllers/api/v1/rides.rb
@@ -139,26 +139,20 @@ module Api
         end
       end
 
+      # Driver completing a ride for a rider
       desc "Complete a ride"
       params do
         requires :ride_id, type: String, desc: "ID of the ride"
       end
       post "rides/:ride_id/complete" do
-        driver = current_driver
-        if driver.is_active == false
-          status 401
-          return "Not Authorized"
-       end
-
         ride = Ride.find(permitted_params[:ride_id])
-        if (ride.driver_id == nil or ride.driver_id ==driver.id)
-          if ride.update(driver_id: driver.id, status: "completed")
-            status 201
-            render ride
-          end
+        if current_driver.is_active? && ride.status == "dropping-off" && ride.driver_id == current_driver.id
+          ride.update(driver_id: current_driver.id, status: "completed")
+          status 201
+          render ride
         else
-           status 401
-           render "Unauthorized"
+          status 401
+          render "Not Authorized"
         end
       end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,17 +8,17 @@
 
 
 
-Organization.create(name: "Durham Rescue Mission", street: "100 Miami Blvd", city: "Durham", state: "North Carolina", zip: "27709")
-Organization.create(name: "Urban Ministires", street: "100 Miami Blvd", city: "Durham", state: "North Carolina", zip: "27709")
-User.create(email: "admin@gmail.com", password: "password",organization_id: 1)
-User.create(email: "admin1@gmail.com", password: "password",organization_id: 2)
+org1 = Organization.create(name: "Durham Rescue Mission", street: "100 Miami Blvd", city: "Durham", state: "North Carolina", zip: "27709")
+org2 = Organization.create(name: "Urban Ministires", street: "100 Miami Blvd", city: "Durham", state: "North Carolina", zip: "27709")
+User.create(email: "admin@gmail.com", password: "password",organization_id: org1.id)
+User.create(email: "admin1@gmail.com", password: "password",organization_id: org2.id)
 
 
 
-Driver.create(organization_id: "1", first_name: "Teddy", last_name: "Ruby", phone: "4086948508", email: "ejr25@duke.edu", password: "password", password_confirmation: "password")
-Driver.create(organization_id: "1", first_name: "John", last_name: "Smith", phone: "4362484055", email: "j.smith@gmail.com", password: "password", password_confirmation: "password")
-Driver.create(organization_id: "1", first_name: "Katie", last_name: "Jones", phone: "92986948508", email: "katie@duke.edu", password: "password", password_confirmation: "password")
-Driver.create(organization_id: "2", first_name: "Sarah", last_name: "Kim", phone: "4029348508", email: "Sarah.Kim@yahoo.com", password: "password", password_confirmation: "password")
+Driver.create(organization_id: org1.id, first_name: "Teddy", last_name: "Ruby", phone: "4086948508", email: "ejr25@duke.edu", password: "password", password_confirmation: "password")
+Driver.create(organization_id: org1.id, first_name: "John", last_name: "Smith", phone: "4362484055", email: "j.smith@gmail.com", password: "password", password_confirmation: "password")
+Driver.create(organization_id: org1.id, first_name: "Katie", last_name: "Jones", phone: "92986948508", email: "katie@duke.edu", password: "password", password_confirmation: "password")
+Driver.create(organization_id: org2.id, first_name: "Sarah", last_name: "Kim", phone: "4029348508", email: "Sarah.Kim@yahoo.com", password: "password", password_confirmation: "password")
 
 Vehicle.create(driver_id: "1", car_make: "Toyota", car_model: "Tacoma", car_color: "Silver", car_year: "2010", car_plate: "ZQWOPQ", seat_belt_num: "4", insurance_provider: "Geico", insurance_start: "2019-02-19", insurance_stop: "2020-02-19" )
 Vehicle.create(driver_id: "2",car_make: "Toyota", car_model: "Camry", car_color: "Blue", car_year: "2010", car_plate: "ZQWOPQ", seat_belt_num: "4", insurance_provider: "Geico", insurance_start: "2019-01-19", insurance_stop: "2020-01-19")
@@ -27,10 +27,10 @@ Vehicle.create(driver_id: "4", car_make: "Nissan", car_model: "Altima", car_colo
 
 
 
-Rider.create(organization_id: "1", first_name: "Katelyn", last_name: "Splint" , phone: "9293842930", email: "ks@duke.edu", password: "password", password_confirmation: "password")
-Rider.create(organization_id: "1", first_name: "James", last_name: "Cage" , phone: "3292842339",  email: "cage@gmail.com", password: "password", password_confirmation: "password")
-Rider.create(organization_id: "1", first_name: "Mary", last_name: "Young" , phone: "52934542930",  email: "myoung@yahoo.com", password: "password", password_confirmation: "password")
-Rider.create(organization_id: "2", first_name: "Jim", last_name: "Free" , phone: "9223842200",  email: "free_j@gmail.com", password: "password", password_confirmation: "password")
+Rider.create(organization_id: org1.id, first_name: "Katelyn", last_name: "Splint" , phone: "9293842930", email: "ks@duke.edu", password: "password", password_confirmation: "password")
+Rider.create(organization_id: org1.id, first_name: "James", last_name: "Cage" , phone: "3292842339",  email: "cage@gmail.com", password: "password", password_confirmation: "password")
+Rider.create(organization_id: org1.id, first_name: "Mary", last_name: "Young" , phone: "52934542930",  email: "myoung@yahoo.com", password: "password", password_confirmation: "password")
+Rider.create(organization_id: org2.id, first_name: "Jim", last_name: "Free" , phone: "9223842200",  email: "free_j@gmail.com", password: "password", password_confirmation: "password")
 
 
 
@@ -63,41 +63,41 @@ Location.create(street: "101 Erwin" , city: "Durham", state: "NC", zip: "27705")
 
 
 
-Ride.create(organization_id: "1", rider_id: "1" ,  pick_up_time: "2022-02-19 15:30:00" , start_location_id: "5", end_location_id: "12", reason: "Interview", status: "pending")
-Ride.create(organization_id: "1", rider_id: "2" ,  pick_up_time: "2022-02-22 08:30:00" ,   start_location_id: "6", end_location_id: "14", reason: "Doctor's appointment", status: "pending")
+Ride.create(organization_id: org1.id, rider_id: "1" ,  pick_up_time: "2022-02-19 15:30:00" , start_location_id: "5", end_location_id: "12", reason: "Interview", status: "pending")
+Ride.create(organization_id: org1.id, rider_id: "2" ,  pick_up_time: "2022-02-22 08:30:00" ,   start_location_id: "6", end_location_id: "14", reason: "Doctor's appointment", status: "pending")
 
-Ride.create(organization_id: "1", rider_id: "3" ,  pick_up_time: "2022-02-23 12:15:00" ,  start_location_id: "7", end_location_id: "15", reason: "Haircut", status: "approved")
-Ride.create(organization_id: "2", rider_id: "4" ,  pick_up_time: "2022-03-11 14:30:00" , start_location_id: "8", end_location_id: "13", reason: "Teacher Conference", status: "approved")
+Ride.create(organization_id: org1.id, rider_id: "3" ,  pick_up_time: "2022-02-23 12:15:00" ,  start_location_id: "7", end_location_id: "15", reason: "Haircut", status: "approved")
+Ride.create(organization_id: org2.id, rider_id: "4" ,  pick_up_time: "2022-03-11 14:30:00" , start_location_id: "8", end_location_id: "13", reason: "Teacher Conference", status: "approved")
 
-Ride.create(organization_id: "1", rider_id: "1" , driver_id: "1" , pick_up_time: "2022-02-19 15:30:00" , start_location_id: "5", end_location_id: "12", reason: "Interview", status: "scheduled")
-Ride.create(organization_id: "1", rider_id: "2" , driver_id: "2" , pick_up_time: "2022-02-22 08:30:00" ,   start_location_id: "6", end_location_id: "14", reason: "Doctor's appointment", status: "scheduled")
-Ride.create(organization_id: "1", rider_id: "3" , driver_id: "3" , pick_up_time: "2022-02-23 12:15:00" ,  start_location_id: "7", end_location_id: "15", reason: "Haircut", status: "scheduled")
-Ride.create(organization_id: "2", rider_id: "4" , driver_id: "4" , pick_up_time: "2022-03-11 14:30:00" , start_location_id: "8", end_location_id: "13", reason: "Teacher Conference", status: "scheduled")
-
-
-Ride.create(organization_id: "1", rider_id: "1" , driver_id: "1" , pick_up_time: "2022-02-19 15:30:00" , start_location_id: "5", end_location_id: "12", reason: "Interview", status: "scheduled")
-Ride.create(organization_id: "1", rider_id: "2" ,  pick_up_time: "2022-02-22 08:30:00" ,   start_location_id: "6", end_location_id: "14", reason: "Doctor's appointment", status: "requested")
-Ride.create(organization_id: "1", rider_id: "3" ,  pick_up_time: "2022-02-23 12:15:00" ,  start_location_id: "7", end_location_id: "15", reason: "Haircut", status: "requested")
-Ride.create(organization_id: "2", rider_id: "4" , driver_id: "4" , pick_up_time: "2022-03-11 14:30:00" , start_location_id: "8", end_location_id: "13", reason: "Teacher Conference", status: "completed")
+Ride.create(organization_id: org1.id, rider_id: "1" , driver_id: "1" , pick_up_time: "2022-02-19 15:30:00" , start_location_id: "5", end_location_id: "12", reason: "Interview", status: "scheduled")
+Ride.create(organization_id: org1.id, rider_id: "2" , driver_id: "2" , pick_up_time: "2022-02-22 08:30:00" ,   start_location_id: "6", end_location_id: "14", reason: "Doctor's appointment", status: "scheduled")
+Ride.create(organization_id: org1.id, rider_id: "3" , driver_id: "3" , pick_up_time: "2022-02-23 12:15:00" ,  start_location_id: "7", end_location_id: "15", reason: "Haircut", status: "scheduled")
+Ride.create(organization_id: org2.id, rider_id: "4" , driver_id: "4" , pick_up_time: "2022-03-11 14:30:00" , start_location_id: "8", end_location_id: "13", reason: "Teacher Conference", status: "scheduled")
 
 
-
-Ride.create(organization_id: "1", rider_id: "1" ,  pick_up_time: "2022-02-20 15:30:00" , start_location_id: "5", end_location_id: "12", reason: "Interview", status: "pending")
-Ride.create(organization_id: "1", rider_id: "2" ,  pick_up_time: "2022-02-23 08:30:00" ,   start_location_id: "6", end_location_id: "14", reason: "Doctor's appointment", status: "pending")
-
-Ride.create(organization_id: "1", rider_id: "3" ,  pick_up_time: "2022-02-24 12:15:00" ,  start_location_id: "7", end_location_id: "15", reason: "Haircut", status: "approved")
-Ride.create(organization_id: "2", rider_id: "4" ,  pick_up_time: "2022-03-14 14:30:00" , start_location_id: "8", end_location_id: "13", reason: "Teacher Conference", status: "approved")
-
-Ride.create(organization_id: "1", rider_id: "1" , driver_id: "1" , pick_up_time: "2022-02-20 15:30:00" , start_location_id: "5", end_location_id: "12", reason: "Interview", status: "scheduled")
-Ride.create(organization_id: "1", rider_id: "2" , driver_id: "2" , pick_up_time: "2022-02-23 08:30:00" ,   start_location_id: "6", end_location_id: "14", reason: "Doctor's appointment", status: "scheduled")
-Ride.create(organization_id: "1", rider_id: "3" , driver_id: "3" , pick_up_time: "2022-02-24 12:15:00" ,  start_location_id: "7", end_location_id: "15", reason: "Haircut", status: "scheduled")
-Ride.create(organization_id: "2", rider_id: "4" , driver_id: "4" , pick_up_time: "2022-03-15 14:30:00" , start_location_id: "8", end_location_id: "13", reason: "Teacher Conference", status: "scheduled")
+Ride.create(organization_id: org1.id, rider_id: "1" , driver_id: "1" , pick_up_time: "2022-02-19 15:30:00" , start_location_id: "5", end_location_id: "12", reason: "Interview", status: "scheduled")
+Ride.create(organization_id: org1.id, rider_id: "2" ,  pick_up_time: "2022-02-22 08:30:00" ,   start_location_id: "6", end_location_id: "14", reason: "Doctor's appointment", status: "requested")
+Ride.create(organization_id: org1.id, rider_id: "3" ,  pick_up_time: "2022-02-23 12:15:00" ,  start_location_id: "7", end_location_id: "15", reason: "Haircut", status: "requested")
+Ride.create(organization_id: org2.id, rider_id: "4" , driver_id: "4" , pick_up_time: "2022-03-11 14:30:00" , start_location_id: "8", end_location_id: "13", reason: "Teacher Conference", status: "completed")
 
 
-Ride.create(organization_id: "1", rider_id: "1" , driver_id: "1" , pick_up_time: "2022-02-22 15:30:00" , start_location_id: "5", end_location_id: "12", reason: "Interview", status: "scheduled")
-Ride.create(organization_id: "1", rider_id: "2" ,  pick_up_time: "2022-02-25 08:30:00" ,   start_location_id: "6", end_location_id: "14", reason: "Doctor's appointment", status: "requested")
-Ride.create(organization_id: "1", rider_id: "3" ,  pick_up_time: "2022-02-25 12:15:00" ,  start_location_id: "7", end_location_id: "15", reason: "Haircut", status: "requested")
-Ride.create(organization_id: "2", rider_id: "4" , driver_id: "4" , pick_up_time: "2022-03-14 14:30:00" , start_location_id: "8", end_location_id: "13", reason: "Teacher Conference", status: "completed")
+
+Ride.create(organization_id: org1.id, rider_id: "1" ,  pick_up_time: "2022-02-20 15:30:00" , start_location_id: "5", end_location_id: "12", reason: "Interview", status: "pending")
+Ride.create(organization_id: org1.id, rider_id: "2" ,  pick_up_time: "2022-02-23 08:30:00" ,   start_location_id: "6", end_location_id: "14", reason: "Doctor's appointment", status: "pending")
+
+Ride.create(organization_id: org1.id, rider_id: "3" ,  pick_up_time: "2022-02-24 12:15:00" ,  start_location_id: "7", end_location_id: "15", reason: "Haircut", status: "approved")
+Ride.create(organization_id: org2.id, rider_id: "4" ,  pick_up_time: "2022-03-14 14:30:00" , start_location_id: "8", end_location_id: "13", reason: "Teacher Conference", status: "approved")
+
+Ride.create(organization_id: org1.id, rider_id: "1" , driver_id: "1" , pick_up_time: "2022-02-20 15:30:00" , start_location_id: "5", end_location_id: "12", reason: "Interview", status: "scheduled")
+Ride.create(organization_id: org1.id, rider_id: "2" , driver_id: "2" , pick_up_time: "2022-02-23 08:30:00" ,   start_location_id: "6", end_location_id: "14", reason: "Doctor's appointment", status: "scheduled")
+Ride.create(organization_id: org1.id, rider_id: "3" , driver_id: "3" , pick_up_time: "2022-02-24 12:15:00" ,  start_location_id: "7", end_location_id: "15", reason: "Haircut", status: "scheduled")
+Ride.create(organization_id: org2.id, rider_id: "4" , driver_id: "4" , pick_up_time: "2022-03-15 14:30:00" , start_location_id: "8", end_location_id: "13", reason: "Teacher Conference", status: "scheduled")
+
+
+Ride.create(organization_id: org1.id, rider_id: "1" , driver_id: "1" , pick_up_time: "2022-02-22 15:30:00" , start_location_id: "5", end_location_id: "12", reason: "Interview", status: "scheduled")
+Ride.create(organization_id: org1.id, rider_id: "2" ,  pick_up_time: "2022-02-25 08:30:00" ,   start_location_id: "6", end_location_id: "14", reason: "Doctor's appointment", status: "requested")
+Ride.create(organization_id: org1.id, rider_id: "3" ,  pick_up_time: "2022-02-25 12:15:00" ,  start_location_id: "7", end_location_id: "15", reason: "Haircut", status: "requested")
+Ride.create(organization_id: org2.id, rider_id: "4" , driver_id: "4" , pick_up_time: "2022-03-14 14:30:00" , start_location_id: "8", end_location_id: "13", reason: "Teacher Conference", status: "completed")
 
 
 
@@ -187,8 +187,8 @@ LocationRelationship.create(location_id: "6", driver_id: nil, rider_id: "2", org
 LocationRelationship.create(location_id: "7", driver_id: nil, rider_id: "3", organization_id: nil)
 LocationRelationship.create(location_id: "8", driver_id: nil, rider_id: "4", organization_id: nil)
 
-LocationRelationship.create(location_id: "9", driver_id: nil, rider_id: nil, organization_id: "1")
-LocationRelationship.create(location_id: "10", driver_id: nil, rider_id: nil, organization_id: "2")
+LocationRelationship.create(location_id: "9", driver_id: nil, rider_id: nil, organization_id: org1.id)
+LocationRelationship.create(location_id: "10", driver_id: nil, rider_id: nil, organization_id: org2.id)
 
 LocationRelationship.create(location_id: "11", driver_id: "1", rider_id: nil, organization_id: nil)
 


### PR DESCRIPTION
- Added a check that drivers can only `accept` rides with status `approved` 
- Added a check that drivers can only `pick up` a rider with status `scheduled` 
- Added a check that drivers can only `drop off` a rider with status `picking-up` 
- Added a check that drivers can only `complete` a ride with status `dropping-off` 
- Added a check that drivers can only `cancel` a ride with status `scheduled`. But, it will put the ride back to `approved` status so other drivers can `accept` them if they want (little tricky)
- Added a check that drivers can `see` only their `own rides` or the `approved` ones
@jrmcgarvey @micronix 

Thank you!





