### PR TITLE
Fix should deprecation

### DIFF
--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -3,22 +3,22 @@ require 'rails_helper'
 RSpec.describe Location, type: :model do
   let(:location) { create :location }
   it "has a valid factory" do
-    FactoryBot.create(:location).should be_valid
+    expect(FactoryBot.create(:location)).to be_valid
   end
 
   describe 'Validations' do
-    it { should validate_presence_of(:street) }
-    it { should validate_presence_of(:city) }
-    it { should validate_presence_of(:state) }
-    it { should validate_presence_of(:zip) }
-    it { should_not allow_value("zipCode").for(:zip) }
-    it { should validate_length_of(:zip).is_equal_to(5) }
+    it { is_expected.to validate_presence_of(:street) }
+    it { is_expected.to validate_presence_of(:city) }
+    it { is_expected.to validate_presence_of(:state) }
+    it { is_expected.to validate_presence_of(:zip) }
+    it { is_expected.not_to allow_value("zipCode").for(:zip) }
+    it { is_expected.to validate_length_of(:zip).is_equal_to(5) }
   end
 
   describe "Associations" do
-    it { should have_many(:location_relationships) }
-    it { should have_many(:schedule_windows) }
-    it { should have_many(:drivers) }
+    it { is_expected.to have_many(:location_relationships) }
+    it { is_expected.to have_many(:schedule_windows) }
+    it { is_expected.to have_many(:drivers) }
   end
 
   describe 'Instance methods' do

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -1,34 +1,34 @@
 require 'rails_helper'
 
 RSpec.describe Organization, type: :model do
-  
+
   it "has a valid factory" do
-    FactoryBot.create(:organization).should be_valid
-  end 
-  
+    expect(FactoryBot.create(:organization)).to be_valid
+  end
+
   describe "Validations" do
-    it { should validate_presence_of(:name) }
-    it { should validate_presence_of(:street) }
-    it { should validate_presence_of(:city) }
-    it { should validate_presence_of(:state) }
-    it { should validate_presence_of(:zip) }
-    # it { should validate_inclusion_of(:use_tokens).in_array([true, false]) }  
-    
+    it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_presence_of(:street) }
+    it { is_expected.to validate_presence_of(:city) }
+    it { is_expected.to validate_presence_of(:state) }
+    it { is_expected.to validate_presence_of(:zip) }
+    # it { should validate_inclusion_of(:use_tokens).in_array([true, false]) }
+
     # ************************************************************************
     # Warning from shoulda-matchers:
-    
+
     # You are using `validate_inclusion_of` to assert that a boolean column
     # allows boolean values and disallows non-boolean ones. Be aware that it
     # is not possible to fully test this, as boolean columns will
     # automatically convert non-boolean values to boolean ones. Hence, you
     # should consider removing this test.
     # ***********************************************************************
-  end 
-  
-  describe "Associations" do
-    it { should have_many(:drivers) }  
-    it { should have_many(:riders) }  
-    it { should have_many(:rides) }  
   end
-  
+
+  describe "Associations" do
+    it { is_expected.to have_many(:drivers) }
+    it { is_expected.to have_many(:riders) }
+    it { is_expected.to have_many(:rides) }
+  end
+
 end

--- a/spec/models/ride_spec.rb
+++ b/spec/models/ride_spec.rb
@@ -3,17 +3,17 @@ require 'rails_helper'
 RSpec.describe Ride, type: :model do
 
   describe 'Validations' do
-    it { should validate_presence_of(:pick_up_time) }
-    it { should validate_presence_of(:reason) }
-    it { should validate_presence_of(:status) }
+    it { is_expected.to validate_presence_of(:pick_up_time) }
+    it { is_expected.to validate_presence_of(:reason) }
+    it { is_expected.to validate_presence_of(:status) }
   end
 
    describe "Associations" do
-    it { should belong_to(:organization) }
-    it { should belong_to(:rider) }
-    it { should belong_to(:start_location) }
-    it { should belong_to(:end_location) }
-    it { should have_one(:token) }
+    it { is_expected.to belong_to(:organization) }
+    it { is_expected.to belong_to(:rider) }
+    it { is_expected.to belong_to(:start_location) }
+    it { is_expected.to belong_to(:end_location) }
+    it { is_expected.to have_one(:token) }
   end
 
 end

--- a/spec/models/rider_spec.rb
+++ b/spec/models/rider_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Rider, type: :model do
   it "has a valid factory" do
-    FactoryBot.create(:rider).should be_valid
+    expect(FactoryBot.create(:rider)).to be_valid
   end
 
   let!(:rider) { create :rider, email: "new_email@example.com" }
@@ -11,15 +11,15 @@ RSpec.describe Rider, type: :model do
 #   let(:token1) { create :token }
 
   describe "Validations" do
-    it { should validate_presence_of(:first_name) }
-    it { should validate_presence_of(:last_name) }
-    it { should validate_presence_of(:phone) }
+    it { is_expected.to validate_presence_of(:first_name) }
+    it { is_expected.to validate_presence_of(:last_name) }
+    it { is_expected.to validate_presence_of(:phone) }
   end
 
   describe "Associations" do
-    it { should belong_to(:organization) }
-    it { should have_many(:tokens) }
-    it { should have_many(:rides) }
+    it { is_expected.to belong_to(:organization) }
+    it { is_expected.to have_many(:tokens) }
+    it { is_expected.to have_many(:rides) }
   end
 
   describe "Instance methods" do  # INSTANCE METHODS TESTS

--- a/spec/models/schedule_window_spec.rb
+++ b/spec/models/schedule_window_spec.rb
@@ -1,55 +1,55 @@
 require 'rails_helper'
 
 RSpec.describe ScheduleWindow, type: :model do
-   
+
     describe "Validations" do
-      it "should validate start date cannot be later than end date" do
+      it "expects to validate start date cannot be later than end date" do
         window =  build(:schedule_window, is_recurring: true, start_date: '2019-10-01', end_date: '2019-09-01')
         expect(window.valid?).to be_falsey
       end
 
-       it "should validate start time cannot be later than end time" do
-        window =  build(:schedule_window, is_recurring: true, start_time: '2019-09-02 1600', end_time: '2019-09-02 1300') 
+       it "expects to validate start time cannot be later than end time" do
+        window =  build(:schedule_window, is_recurring: true, start_time: '2019-09-02 1600', end_time: '2019-09-02 1300')
         expect(window.valid?).to be_falsey
       end
 
-      it "should validate start date cannot be later than start time" do
-        window = build(:schedule_window, is_recurring: true, start_date: '2019-09-01', start_time: '2019-08-01 12:00') 
+      it "expects to validate start date cannot be later than start time" do
+        window = build(:schedule_window, is_recurring: true, start_date: '2019-09-01', start_time: '2019-08-01 12:00')
         expect(window.valid?).to be_falsey
       end
 
-      it "should validate end date cannot be before end time" do
-        window =   build(:schedule_window, is_recurring: true, end_date: '2019-10-02 1600', end_time: '2019-10-12 1400') 
+      it "expects to validate end date cannot be before end time" do
+        window =   build(:schedule_window, is_recurring: true, end_date: '2019-10-02 1600', end_time: '2019-10-12 1400')
         expect(window.valid?).to be_falsey
       end
     end
 
     describe "Associations" do
-      it { should belong_to(:driver) }
-      it { should have_one(:recurring_pattern) }
-      it { should belong_to(:location) }
+      it { is_expected.to belong_to(:driver) }
+      it { is_expected.to have_one(:recurring_pattern) }
+      it { is_expected.to belong_to(:location) }
     end
 
     describe 'Cannot be in the past' do
-      it "should validate that start time cannot be in the past" do
+      it "expects to validate that start time cannot be in the past" do
         subject.start_time = "2019-07-01"
         subject.valid?  # run validations
         expect(subject.errors[:start_time]).to include('cannot be in the past')
       end
 
-      it "should validate that end time cannot be in the past" do
+      it "expects to validate that end time cannot be in the past" do
         subject.end_time = "2019-07-01"
         subject.valid?
         expect(subject.errors[:end_time]).to include('cannot be in the past')
       end
 
-      it "should validate that start date cannot be in the past" do
+      it "expects to validate that start date cannot be in the past" do
         subject.start_date = "2019-07-01"
         subject.valid?  # run validations
         expect(subject.errors[:start_date]).to include('cannot be in the past')
       end
 
-      it "should validate that end date cannot be in the past" do
+      it "expects to validate that end date cannot be in the past" do
         subject.end_date = "2019-07-01"
         subject.valid?
         expect(subject.errors[:end_date]).to include('cannot be in the past')
@@ -57,37 +57,37 @@ RSpec.describe ScheduleWindow, type: :model do
     end
 
     describe 'Cannot be overlapped' do
-      it "should validate that end time cannot be before start time" do
+      it "expects to validate that end time cannot be before start time" do
         subject.start_time = "2019-07-01 9:00am"
         subject.end_time = "2019-07-01 9:00am"
         subject.valid?  # run validations
         expect(subject.valid?).to be_falsey
       end
 
-      it "should validate that end date cannot be before start date" do
+      it "expects to validate that end date cannot be before start date" do
         subject.start_time = "2019-07-01"
         subject.end_time = "2019-07-01"
         subject.valid?  # run validations
         expect(subject.valid?).to be_falsey
       end
     end
-      
+
       describe 'recurring weekly' do
         begin_time = DateTime.now. +  1.day + 1.hour
         let(:recurring_pattern) { create(:recurring_weekly_pattern, begin_time: begin_time ) }
-        
+
        describe 'recurring weekly' do
         let(:recurring_pattern) { create(:recurring_weekly_pattern) }
-  
-        it "should return weekly events" do
+
+        it "expects to return weekly events" do
           start_date = Date.parse('2025-09-11')
           end_date = Date.parse('2025-09-25')
-          
+
           events = recurring_pattern.schedule_window.recurring_weekly(start_date, end_date)
-          
+
           # check correct number of events
           expect(events.length).to eq(2)
-          
+
           # check that start times are correct
           start_times = events.map{|k| k[:startTime] }
           expect(start_times).to eq(['2025-09-20 14:00', '2025-09-13 14:00'])
@@ -96,80 +96,80 @@ RSpec.describe ScheduleWindow, type: :model do
           end_times = events.map{|k| k[:endTime] }
           # expect(end_times).to eq(['2025-09-20 16:00', '2025-09-13 16:00'])
         end
-        
-        it "should return an empty [] when query is after the date range of the schedule window" do
+
+        it "expects to return an empty [] when query is after the date range of the schedule window" do
           query_start_date = Date.parse('2025-10-20')
           query_end_date = Date.parse('2025-11-27')
-           
+
           events = recurring_pattern.schedule_window.recurring_weekly(query_start_date, query_end_date)
-          
+
           #check that array is empty
           expect(events).to eq([])
       end
-      
-       it "should return an empty [] when query is before the date range of the schedule window" do
+
+       it "expects to return an empty [] when query is before the date range of the schedule window" do
           query_start_date = Date.parse('2025-08-01')
           query_end_date = Date.parse('2025-08-31')
-           
+
           events = recurring_pattern.schedule_window.recurring_weekly(query_start_date, query_end_date)
-          
+
           #check that array is empty
           expect(events).to eq([])
         end
-        
-        it "should return [] of events when query is before the schedule window start date but in range of the end date" do
+
+        it "expects to return [] of events when query is before the schedule window start date but in range of the end date" do
           query_start_date = Date.parse("2025-08-01")
           query_end_date = Date.parse("2025-09-21")
-          
+
           events = recurring_pattern.schedule_window.recurring_weekly(query_start_date, query_end_date)
-          
+
           #check correct number of events
           expect(events.length).to eq(3)
-        
+
           # check that start times are correct
           start_times = events.map{|k| k[:startTime] }
           expect(start_times).to eq(["2025-09-20 14:00","2025-09-13 14:00","2025-09-06 14:00"])
-          
-          
+
+
           # check that end times are correct
           end_dates = events.map{|k| k[:endTime] }
           expect(end_dates).to eq(["2025-09-20 16:00", "2025-09-13 16:00", "2025-09-06 16:00"])
         end
-        
-        it "should return an [] of events when query is in range of the schedule window start date but past the end date" do
+
+        it "expects to return an [] of events when query is in range of the schedule window start date but past the end date" do
           query_start_date = Date.parse("2025-10-01")
           query_end_date = Date.parse("2025-11-21")
-          
+
           events = recurring_pattern.schedule_window.recurring_weekly(query_start_date, query_end_date)
-          
+
           #check correct number of events
           expect(events.length).to eq(3)
-        
+
           # check that start times are correct
           start_times = events.map{|k| k[:startTime] }
           expect(start_times).to eq(["2025-10-18 14:00","2025-10-11 14:00","2025-10-04 14:00"])
-          
-          
+
+
           # check that end times are correct
           end_dates = events.map{|k| k[:endTime] }
           expect(end_dates).to eq(["2025-10-18 16:00","2025-10-11 16:00","2025-10-04 16:00"])
         end
-        
-        it "should return and [] of events when query is before schedule window start_date and range is pass the end date" do
+
+        it "expects return and [] of events when query is before schedule window start_date and range is pass the end date" do
           query_start_date = Date.parse("2025-08-01")
           query_end_date = Date.parse("2025-11-30")
-          
+
           events = recurring_pattern.schedule_window.recurring_weekly(query_start_date, query_end_date)
-          
+
           # check that start times are correct
           expect(events.length).to eq(7)
-          
+
           # check that start times are correct
           start_times = events.map{|k| k[:startTime] }
           expect(start_times).to eq(["2025-10-18 14:00","2025-10-11 14:00","2025-10-04 14:00", "2025-09-27 14:00",
           "2025-09-20 14:00", "2025-09-13 14:00", "2025-09-06 14:00" ])
-          
-          
+
+
           # check that end times are correct
           end_times = events.map{|k| k[:endTime] }
            expect(end_times).to  eq(["2025-10-18 16:00","2025-10-11 16:00","2025-10-04 16:00", "2025-09-27 16:00",

--- a/spec/models/vehicle_spec.rb
+++ b/spec/models/vehicle_spec.rb
@@ -3,19 +3,19 @@ require 'rails_helper'
 RSpec.describe Vehicle, type: :model do
 
   describe "Validations" do
-      it { should validate_presence_of(:car_make) }
-      it { should validate_presence_of(:car_model) }
-      it { should validate_presence_of(:car_color) }
-      it { should validate_presence_of(:car_year) }
-      it { should validate_presence_of(:car_plate) }
-      it { should validate_presence_of(:seat_belt_num) }
-      it { should validate_presence_of(:insurance_provider) }
-      it { should validate_presence_of(:insurance_start) }
-      it { should validate_presence_of(:insurance_stop) }
+      it { is_expected.to validate_presence_of(:car_make) }
+      it { is_expected.to validate_presence_of(:car_model) }
+      it { is_expected.to validate_presence_of(:car_color) }
+      it { is_expected.to validate_presence_of(:car_year) }
+      it { is_expected.to validate_presence_of(:car_plate) }
+      it { is_expected.to validate_presence_of(:seat_belt_num) }
+      it { is_expected.to validate_presence_of(:insurance_provider) }
+      it { is_expected.to validate_presence_of(:insurance_start) }
+      it { is_expected.to validate_presence_of(:insurance_stop) }
   end
 
   describe "Associations" do
-      it { should belong_to(:driver) }
+      it { is_expected.to belong_to(:driver) }
   end
 
 end


### PR DESCRIPTION
- Fix `shoulda-matchers` deprecation warnings in model tests by replacing it with `expects` throughout the tests
@jrmcgarvey @micronix 

Thank you!