### PR TITLE
Token management

### DIFF
--- a/app/views/riders/_form.html.erb
+++ b/app/views/riders/_form.html.erb
@@ -56,15 +56,19 @@
 <div class="row">
     <% if yield(:button_text) == "Create" %>
       <div class="form-group offset-md-1 col-md-9">
-        <%= link_to "back", riders_path, class: "btn btn-outline-primary" %>
+        <%= link_to "back", :back, class: "btn btn-outline-primary" %>
       </div>
 
       <div  class="form-group col-md-2">
         <%= form.submit yield(:button_text), class: "btn btn-outline-success" %>
       </div>
     <% else %>
-      <div  class="form-group col-md-1 offset-md-10">
-        <%= form.submit yield(:button_text), class: "btn btn-sm btn-outline-success" %>
+      <div class="form-group offset-md-1 col-md-9">
+        <%= link_to "back", :back, class: "btn btn-outline-primary" %>
+      </div>
+
+      <div  class="form-group col-md-2">
+        <%= form.submit yield(:button_text), class: "btn btn-outline-success" %>
       </div>
     <% end %>
 </div>

--- a/app/views/riders/_rider_info.html.erb
+++ b/app/views/riders/_rider_info.html.erb
@@ -1,13 +1,13 @@
 <div class="ml-5">
   <div class="row">
     <div class="col-md border-top border-bottom">
-      <strong>Name:</strong>
-      <%= @rider.full_name %>
+      <strong>First name:</strong>
+      <%= @rider.first_name %>
     </div>
 
     <div class="col-md border-top border-bottom">
-      <strong>Email:</strong>
-      <%= @rider.email %>
+      <strong>Last name:</strong>
+      <%= @rider.last_name %>
     </div>
   </div>
   <div class="row">
@@ -16,11 +16,8 @@
       <%= number_to_phone(@rider.phone) %>
     </div>
     <div class="col-md border-top border-bottom">
-      <strong>Valid tokens:</strong>
-      <%= @rider.valid_tokens_count %>
-      <%= link_to edit_rider_path(@rider), class: "btn btn-sm btn-outline-success", id: "my-button" do %>
-        <i class="fa fa-tasks"> Manage</i>
-      <% end %>
+        <strong>Email:</strong>
+        <%= @rider.email %>
     </div>
   </div>
   <div class="row">

--- a/app/views/riders/_rider_info_with_tokens.html.erb
+++ b/app/views/riders/_rider_info_with_tokens.html.erb
@@ -1,0 +1,39 @@
+<div class="ml-5">
+  <div class="row">
+    <div class="col-md border-top border-bottom">
+      <strong>Name:</strong>
+      <%= @rider.full_name %>
+    </div>
+
+    <div class="col-md border-top border-bottom">
+      <strong>Email:</strong>
+      <%= @rider.email %>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md border-top border-bottom">
+      <strong>Phone:</strong>
+      <%= number_to_phone(@rider.phone) %>
+    </div>
+    <div class="col-md border-top border-bottom">
+      <strong>Valid tokens:</strong>
+      <%= @rider.valid_tokens_count %>
+      <%= link_to edit_rider_path(@rider), class: "btn btn-sm btn-outline-success", id: "my-button" do %>
+        <i class="fa fa-tasks"> Manage</i>
+      <% end %>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md border-top border-bottom">
+      <strong>Organization:</strong>
+      <%= @rider.organization.name %>
+    </div>
+    <div class="col-md border-top border-bottom">
+      <strong>Active:</strong>
+      <%= driver_active_inactive(@rider.is_active) %>
+    </div>
+  </div>
+  <div class="driver-show-page-buttons">
+    <%= link_to 'Edit', edit_rider_path(@rider), class:"btn btn-sm btn-outline-info"%>
+  </div>
+</div>

--- a/app/views/riders/edit.html.erb
+++ b/app/views/riders/edit.html.erb
@@ -8,12 +8,9 @@
             <strong class="text-white">Update Rider</strong>
         </h5>
         <%= render 'form' %>
-        <%= render 'bulk_form' %>
-        <div class="row">
-          <div  class="form-group offset-md-1 col-md-10">
-            <%= link_to 'Back', riders_path, class: "btn btn-primary" %>
-          </div>
-        </div>
-
+        <% if current_user.organization.use_tokens? %>
+          <%= render 'bulk_form' %>
+        <% end %><br/>
     </div>
+
 </div>

--- a/app/views/riders/show.html.erb
+++ b/app/views/riders/show.html.erb
@@ -12,7 +12,11 @@
         <% end %>
       <% end %>
     </h3>
-    <%= render 'rider_info' %>
+    <% if current_user.organization.use_tokens? %>
+      <%= render 'rider_info_with_tokens' %>
+    <% else %>
+      <%= render 'rider_info' %>
+    <% end %>
   </div>
 
   <div class="card3">

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Location, type: :model do
 
   describe 'Instance methods' do
     it "returns a location's full address as string" do
-      expect(location.full_address).to eq("800 Park Offices Dr, Morrisville, NC 27560")
+      expect(location.full_address).to eq("800 Park Offices Dr, Research Triangle, NC 27560")
     end
   end
 

--- a/spec/requests/locations_spec.rb
+++ b/spec/requests/locations_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe Api::V1::Locations, type: :request do
 
       parsed_json = JSON.parse(response.body)
       expect(parsed_json['location']['street']).to eq('800 Park Offices Dr')
-      expect(parsed_json['location']['city']).to eq('Morrisville')
+      expect(parsed_json['location']['city']).to eq('Research Triangle')
       expect(parsed_json['location']['state']).to eq('NC')
       expect(parsed_json['location']['zip']).to eq( "27560")
       expect(response).to have_http_status(200)


### PR DESCRIPTION
- Put a check that `token` management form is displayed on rider `edit` form only if the organization uses token
- Adjusted the `rider info` form partial such that it display `valid tokens` only if the organization uses token (added a separate form partial to accomplish this)
- Fixed failing tests after above changes made

@jrmcgarvey @micronix 

Thank you!