### PR TITLE
Remove status checks from ride endpoints

### DIFF
--- a/app/controllers/admin_ride_controller.rb
+++ b/app/controllers/admin_ride_controller.rb
@@ -17,14 +17,12 @@ class AdminRideController < ApplicationController
     authorize @ride
   end
 
-
   def index
     @rides = Ride.where(organization: current_user.organization)
     @rides = Ride.status(params[:status]).where(organization: current_user.organization) if params[:status].present?
-    @rides = Kaminari.paginate_array(@rides).page(params[:page]).per(RIDES_PER_PAGE_AMOUNT)
 
-    @quary = Ride.joins(:rider).ransack(params[:q])
-    @search = @quary.result
+    @query = @rides.joins(:rider).ransack(params[:q])
+    @search = Kaminari.paginate_array(@query.result).page(params[:page]).per(RIDES_PER_PAGE_AMOUNT)
   end
 
   def edit

--- a/app/controllers/api/v1/rides.rb
+++ b/app/controllers/api/v1/rides.rb
@@ -142,8 +142,8 @@ module Api
       end
       post "rides/:ride_id/complete" do
         ride = Ride.find(permitted_params[:ride_id])
-        if current_driver.is_active? && ride.status == "dropping-off" && ride.driver_id == current_driver.id
-          ride.update(driver_id: current_driver.id, status: "completed")
+        if current_driver.is_active? && ride.driver_id == current_driver.id
+          ride.update(status: "completed")
           status 201
           render ride
         else
@@ -165,6 +165,10 @@ module Api
           ride.update(driver_id: nil, status: "approved")
           status 201
           render ride
+        elsif current_driver.is_active? && ride.driver_id == current_driver.id
+          ride.update(status: "canceled")
+          status 201
+          render ride
         else
           status 401
           render "Not Authorized"
@@ -178,8 +182,8 @@ module Api
       end
       post "rides/:ride_id/picking-up" do
         ride = Ride.find(permitted_params[:ride_id])
-        if current_driver.is_active? && ride.status == "scheduled" && ride.driver_id == current_driver.id
-          ride.update(driver_id: current_driver.id, status: "picking-up")
+        if current_driver.is_active? && ride.driver_id == current_driver.id
+          ride.update(status: "picking-up")
           status 201
           render ride
         else
@@ -195,8 +199,8 @@ module Api
       end
       post "rides/:ride_id/dropping-off" do
         ride = Ride.find(permitted_params[:ride_id])
-        if current_driver.is_active? && ride.status == "picking-up" && ride.driver_id == current_driver.id
-          ride.update(driver_id: current_driver.id, status: "dropping-off")
+        if current_driver.is_active? && ride.driver_id == current_driver.id
+          ride.update(status: "dropping-off")
           status 201
           render ride
         else

--- a/app/controllers/api/v1/rides.rb
+++ b/app/controllers/api/v1/rides.rb
@@ -250,7 +250,7 @@ module Api
       end
       post "rides/:ride_id/cancel" do
         ride = Ride.find(permitted_params[:ride_id])
-        if current_driver.is_active? && ride.driver_id == current_driver.id
+        if current_driver.is_active? && ride.status != "scheduled" && ride.driver_id == current_driver.id
           ride.update(status: "canceled")
           status 201
           render ride

--- a/spec/requests/rides_spec.rb
+++ b/spec/requests/rides_spec.rb
@@ -105,7 +105,13 @@ RSpec.describe Api::V1::Rides, type: :request do
 
   end
 
-  it 'will cancel a ride for a driver' do
+  it 'will put the ride to CANCELED status when canceled a ride with no scheduled status' do
+    post "/api/v1/rides/#{ride2.id}/cancel",  headers: {"ACCEPT" => "application/json",  "Token" => "1234"}
+    parsed_json = JSON.parse(response.body)
+    expect(parsed_json['ride']['status']).to eq("canceled")
+  end
+
+  it 'will put the ride back to APPROVED status when canceled a ride with scheduled status' do
     post "/api/v1/rides/#{ride1.id}/cancel",  headers: {"ACCEPT" => "application/json",  "Token" => "1234"}
     parsed_json = JSON.parse(response.body)
     expect(parsed_json['ride']['status']).to eq("approved")

--- a/spec/requests/vehicles_controller_spec.rb
+++ b/spec/requests/vehicles_controller_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe Api::V1::Vehicles, type: :request do
 
         #Needs Index [0] because returns 2 vehicles
         expect(parsed_json['vehicle'][0]['car_make']).to eq('Nissan')
-        expect(parsed_json['vehicle'][0]['car_year']).to eq(2010)
+        expect(parsed_json['vehicle'][0]['car_year']).to eq(2017)
         expect(parsed_json['vehicle'][0]['car_color']).to eq('Silver')
         expect(parsed_json['vehicle'][0]['insurance_provider']).to eq('Geico')
         #Dates a formatted when they are accepted so appear slightly different than above


### PR DESCRIPTION
- Removed `status` checks from ride endpoints
- Fixed failing tests
- Added additional tests for ride cancellation. If a ride with `scheduled` status is cancelled, it will put the ride back to `approved` status. For other statuses, it will put the ride to `canceled` status.

@jrmcgarvey @micronix 

Thank you!