### PR TITLE
Add fields on ride serializer

### DIFF
--- a/app/serializers/ride_serializer.rb
+++ b/app/serializers/ride_serializer.rb
@@ -1,5 +1,5 @@
 class RideSerializer < ActiveModel::Serializer
   ActiveModelSerializers.config.adapter = :json
-  attributes :id, :organization_id, :rider_id, :driver_id, :pick_up_time, :start_location, :end_location,  :reason, :status
+  attributes :id, :organization_id, :rider_id, :driver_id, :pick_up_time, :start_location, :end_location,  :reason, :status, :round_trip, :expected_wait_time
 
 end

--- a/app/views/admin_ride/_form.html.erb
+++ b/app/views/admin_ride/_form.html.erb
@@ -217,7 +217,7 @@
 <div class="form-row">
   <div id="show_dep" style="display: none" class="form-group  col-md-10 offset-md-1">
     7. <%= form.label :expected_wait_time %>
-       <%= form.select :expected_wait_time, options_for_select([["30 mins", "30"],["45 mins", "45"], ["1.0 hour", "60"], ["1.5 hours", "90"],["2.0 hours", "120"], ["2.5 hours", "150"], ["3.0 hours", "180"]], "#{@ride.expected_wait_time}"), class: "form-control" %>
+       <%= form.select :expected_wait_time, options_for_select([["", ""], ["30 mins", "30"],["45 mins", "45"], ["1.0 hour", "60"], ["1.5 hours", "90"],["2.0 hours", "120"], ["2.5 hours", "150"], ["3.0 hours", "180"]], "#{@ride.expected_wait_time}"), class: "form-control" %>
   </div>
 </div>
 <div class="form-row">


### PR DESCRIPTION
- Added `round_trip` and `expected_wait_time` fields on ride `serializer` so front end can access them
- Changed `expected_wait_time` default value to `blank` on ride form
@jrmcgarvey @micronix 

Thank you!
