### PR TITLE
Driver signups by admins

### DIFF
--- a/app/controllers/admin/drivers_controller.rb
+++ b/app/controllers/admin/drivers_controller.rb
@@ -51,7 +51,8 @@ class Admin::DriversController < ApplicationController
     @driver.organization_id = current_user.organization_id
 
     if @driver.save
-      flash.notice = "Driver created."
+      DriverMailer.signup_confirmation(@driver).deliver
+      flash.notice = "Sign up confirmation email sent to the driver."
       redirect_to admin_driver_path(@driver)
     else
       flash[:error] = @driver.errors.full_messages

--- a/app/mailers/driver_mailer.rb
+++ b/app/mailers/driver_mailer.rb
@@ -1,13 +1,9 @@
 class DriverMailer < ApplicationMailer
+  default from: "noreply@ctd-crsn.org"
 
-  # Subject can be set in your I18n file at config/locales/en.yml
-  # with the following lookup:
-  #
-  #   en.driver_mailer.signup_confirmation.subject
-  #
-  def signup_confirmation
-    @greeting = "Hi"
+  def signup_confirmation(driver)
+    @driver = driver
 
-    mail to: "to@example.org"
+    mail to: driver.email, subject: "Sign up confirmation"
   end
 end

--- a/app/mailers/driver_mailer.rb
+++ b/app/mailers/driver_mailer.rb
@@ -1,0 +1,13 @@
+class DriverMailer < ApplicationMailer
+
+  # Subject can be set in your I18n file at config/locales/en.yml
+  # with the following lookup:
+  #
+  #   en.driver_mailer.signup_confirmation.subject
+  #
+  def signup_confirmation
+    @greeting = "Hi"
+
+    mail to: "to@example.org"
+  end
+end

--- a/app/views/driver_mailer/signup_confirmation.html.erb
+++ b/app/views/driver_mailer/signup_confirmation.html.erb
@@ -1,0 +1,5 @@
+<h1>Driver#signup_confirmation</h1>
+
+<p>
+  <%= @greeting %>, find me in app/views/driver_mailer/signup_confirmation.html.erb
+</p>

--- a/app/views/driver_mailer/signup_confirmation.html.erb
+++ b/app/views/driver_mailer/signup_confirmation.html.erb
@@ -1,5 +1,19 @@
-<h1>Driver#signup_confirmation</h1>
+<p>
+  Hi <%= @driver.first_name %>,
+</p>
 
 <p>
-  <%= @greeting %>, find me in app/views/driver_mailer/signup_confirmation.html.erb
+  You have been signed up as a new driver for CRSN.
+</p>
+
+<p style="font-variant: normal;">
+  YOUR PASSWORD: <%= @driver.password %>
+</p><br/>
+
+<p>
+  Thank you for volunteering with us!
+</p>
+
+<p>
+  - CRSN
 </p>

--- a/app/views/driver_mailer/signup_confirmation.text.erb
+++ b/app/views/driver_mailer/signup_confirmation.text.erb
@@ -1,3 +1,10 @@
-Driver#signup_confirmation
+Hi <%= @driver.first_name %>,
 
-<%= @greeting %>, find me in app/views/driver_mailer/signup_confirmation.text.erb
+You have been signed up as a new driver for CRSN.
+
+YOUR PASSWORD: <%= @driver.password %>
+
+
+Thank you for volunteering with us!
+
+- CRSN

--- a/app/views/driver_mailer/signup_confirmation.text.erb
+++ b/app/views/driver_mailer/signup_confirmation.text.erb
@@ -1,0 +1,3 @@
+Driver#signup_confirmation
+
+<%= @greeting %>, find me in app/views/driver_mailer/signup_confirmation.text.erb

--- a/spec/controllers/admin_rides_controller_spec.rb
+++ b/spec/controllers/admin_rides_controller_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe AdminRideController, type: :controller do
                                                           end_zip: "27705",
                                                           reason: "Doctor visit",
                                                           status: "approved",
-                                                          round_trip: true,
+                                                          round_trip: false,
                                                           expected_wait_time: 45
                                                         }
                                                   }

--- a/spec/controllers/drivers_controller_spec.rb
+++ b/spec/controllers/drivers_controller_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Admin::DriversController, type: :controller do
         }
       }
 
-      expect(flash[:notice]).to match("Driver created.")
+      expect(flash[:notice]).to match("Sign up confirmation email sent to the driver.")
       expect(test_response.response_code).to eq(302)
       expect(test_response).to redirect_to(admin_driver_path(Driver.last))
     end.to change(Driver, :count)

--- a/spec/features/users/user_password_reset_spec.rb
+++ b/spec/features/users/user_password_reset_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "Users::UserPasswordResets", type: :feature do
 
   scenario "user receives a password reset link if a valid email is provided" do
     visit root_path
-    expect(page).to have_text "Rideshare"
+    expect(page).to have_text "CRSN"
     click_link 'admin-login'
     expect(page).to have_text "Log in"
     click_link "Forgot your password?"

--- a/spec/fixtures/driver_mailer/signup_confirmation
+++ b/spec/fixtures/driver_mailer/signup_confirmation
@@ -1,0 +1,3 @@
+DriverMailer#signup_confirmation
+
+Hi, find me in app/views/driver_mailer/signup_confirmation

--- a/spec/mailers/driver_mailer_spec.rb
+++ b/spec/mailers/driver_mailer_spec.rb
@@ -1,13 +1,15 @@
 require "rails_helper"
 
 RSpec.describe DriverMailer, type: :mailer do
+  let!(:driver) { Driver.create(first_name: "John", last_name: "Doe", email: "john.doe@gmail.com", password: "password")
+  }
   describe "signup_confirmation" do
-    let(:mail) { DriverMailer.signup_confirmation }
+    let(:mail) { DriverMailer.signup_confirmation(driver) }
 
     it "renders the headers" do
-      expect(mail.subject).to eq("Signup confirmation")
-      expect(mail.to).to eq(["to@example.org"])
-      expect(mail.from).to eq(["from@example.com"])
+      expect(mail.subject).to eq("Sign up confirmation")
+      expect(mail.to).to eq([driver.email])
+      expect(mail.from).to eq(["noreply@ctd-crsn.org"])
     end
 
     it "renders the body" do

--- a/spec/mailers/driver_mailer_spec.rb
+++ b/spec/mailers/driver_mailer_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.describe DriverMailer, type: :mailer do
+  describe "signup_confirmation" do
+    let(:mail) { DriverMailer.signup_confirmation }
+
+    it "renders the headers" do
+      expect(mail.subject).to eq("Signup confirmation")
+      expect(mail.to).to eq(["to@example.org"])
+      expect(mail.from).to eq(["from@example.com"])
+    end
+
+    it "renders the body" do
+      expect(mail.body.encoded).to match("Hi")
+    end
+  end
+
+end

--- a/spec/mailers/previews/driver_mailer_preview.rb
+++ b/spec/mailers/previews/driver_mailer_preview.rb
@@ -1,0 +1,9 @@
+# Preview all emails at http://localhost:3000/rails/mailers/driver_mailer
+class DriverMailerPreview < ActionMailer::Preview
+
+  # Preview this email at http://localhost:3000/rails/mailers/driver_mailer/signup_confirmation
+  def signup_confirmation
+    DriverMailer.signup_confirmation
+  end
+
+end


### PR DESCRIPTION
- Added admin ability to sign up for a new driver thereby sending a signup confirmation email to drivers with temporary PWD.
- Added driver sign up mailer tests.

@jrmcgarvey 

Thanks!