### PR TITLE
Driver default to pickup distance

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 class ApplicationController < ActionController::Base
   #Make devise model accept other params than
   #email password and password_confirmation
-  
+  serialization_scope :current_driver
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   include Pundit

--- a/app/models/ride.rb
+++ b/app/models/ride.rb
@@ -115,7 +115,7 @@ class Ride < ApplicationRecord
     else
       return nil
     end
-    geodistance.calculate_distance # calculate_distance method called from Geodistance helper method
+    geodistance.calculate_distance.round(1) # calculate_distance method called from Geodistance helper method
   end
 
   def set_distance

--- a/app/serializers/ride_serializer.rb
+++ b/app/serializers/ride_serializer.rb
@@ -9,7 +9,7 @@ class RideSerializer < ActiveModel::Serializer
     if default_location_relationship != nil
       driver_default_location = Location.find(default_location_relationship.location_id)
       geodistance = Geodistance.new(driver_default_location, object.start_location)
-      return geodistance.calculate_distance
+      return geodistance.calculate_distance.round(1)
     else
       return nil
     end

--- a/app/serializers/ride_serializer.rb
+++ b/app/serializers/ride_serializer.rb
@@ -1,6 +1,18 @@
 class RideSerializer < ActiveModel::Serializer
   ActiveModelSerializers.config.adapter = :json
   attributes :id, :organization_id, :rider_id, :driver_id, :pick_up_time, :start_location, :end_location,  :reason, :status, :completed_at, :round_trip, :expected_wait_time,
-  :pickup_to_dropoff_distance, :pickup_to_dropoff_time
+  :pickup_to_dropoff_distance, :pickup_to_dropoff_time, :default_to_pickup_distance
+
+  def default_to_pickup_distance
+    #access driver's default address here. It's one specific address to a driver
+    default_location_relationship = scope.current_driver.location_relationships.find_by(default: true)
+    if default_location_relationship != nil
+      driver_default_location = Location.find(default_location_relationship.location_id)
+      geodistance = Geodistance.new(driver_default_location, object.start_location)
+      return geodistance.calculate_distance
+    else
+      return nil
+    end
+  end
 
 end

--- a/db/migrate/20200505235750_add_default_to_location_relationships.rb
+++ b/db/migrate/20200505235750_add_default_to_location_relationships.rb
@@ -1,0 +1,5 @@
+class AddDefaultToLocationRelationships < ActiveRecord::Migration[5.2]
+  def change
+    add_column :location_relationships, :default, :boolean, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_02_022908) do
+ActiveRecord::Schema.define(version: 2020_05_05_235750) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -66,6 +66,7 @@ ActiveRecord::Schema.define(version: 2020_05_02_022908) do
     t.bigint "organization_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "default", null: false
     t.index ["driver_id"], name: "index_location_relationships_on_driver_id"
     t.index ["location_id"], name: "index_location_relationships_on_location_id"
     t.index ["organization_id"], name: "index_location_relationships_on_organization_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -179,34 +179,34 @@ RecurringPattern.create(schedule_window_id: sw15.id , day_of_week: "0")
 RecurringPattern.create(schedule_window_id: sw16.id , day_of_week: "0")
 
 
-LocationRelationship.create(location_id: loc1.id , driver_id: driver1.id , rider_id: nil, organization_id: nil)
-LocationRelationship.create(location_id: loc2.id , driver_id: driver1.id , rider_id: nil, organization_id: nil)
-LocationRelationship.create(location_id: loc3.id , driver_id: driver1.id , rider_id: nil, organization_id: nil)
-LocationRelationship.create(location_id: loc4.id , driver_id: driver1.id , rider_id: nil, organization_id: nil)
+LocationRelationship.create(default: false, location_id: loc1.id , driver_id: driver1.id , rider_id: nil, organization_id: nil)
+LocationRelationship.create(default: false, location_id: loc2.id , driver_id: driver1.id , rider_id: nil, organization_id: nil)
+LocationRelationship.create(default: false, location_id: loc3.id , driver_id: driver1.id , rider_id: nil, organization_id: nil)
+LocationRelationship.create(default: false, location_id: loc4.id , driver_id: driver1.id , rider_id: nil, organization_id: nil)
 
-LocationRelationship.create(location_id: loc5.id , driver_id: nil, rider_id: rider1, organization_id: nil)
-LocationRelationship.create(location_id: loc6.id , driver_id: nil, rider_id: rider2, organization_id: nil)
-LocationRelationship.create(location_id: loc7.id , driver_id: nil, rider_id: rider3, organization_id: nil)
-LocationRelationship.create(location_id: loc8.id , driver_id: nil, rider_id: rider4, organization_id: nil)
+LocationRelationship.create(default: false, location_id: loc5.id , driver_id: nil, rider_id: rider1, organization_id: nil)
+LocationRelationship.create(default: false, location_id: loc6.id , driver_id: nil, rider_id: rider2, organization_id: nil)
+LocationRelationship.create(default: false, location_id: loc7.id , driver_id: nil, rider_id: rider3, organization_id: nil)
+LocationRelationship.create(default: false, location_id: loc8.id , driver_id: nil, rider_id: rider4, organization_id: nil)
 
-LocationRelationship.create(location_id: loc9.id , driver_id: nil, rider_id: nil, organization_id: org1.id)
-LocationRelationship.create(location_id: loc10.id , driver_id: nil, rider_id: nil, organization_id: org2.id)
+LocationRelationship.create(default: false, location_id: loc9.id , driver_id: nil, rider_id: nil, organization_id: org1.id)
+LocationRelationship.create(default: false, location_id: loc10.id , driver_id: nil, rider_id: nil, organization_id: org2.id)
 
-LocationRelationship.create(location_id: loc11.id , driver_id: driver1.id , rider_id: nil, organization_id: nil)
+LocationRelationship.create(default: true, location_id: loc11.id , driver_id: driver1.id , rider_id: nil, organization_id: nil)
 
-LocationRelationship.create(location_id: loc12.id , driver_id: nil, rider_id: nil, organization_id: nil)
-LocationRelationship.create(location_id: loc13.id , driver_id: nil, rider_id: nil, organization_id: nil)
-LocationRelationship.create(location_id: loc14.id , driver_id: nil, rider_id: nil, organization_id: nil)
-LocationRelationship.create(location_id: loc15.id , driver_id: nil, rider_id: nil, organization_id: nil)
-
-
+LocationRelationship.create(default: false, location_id: loc12.id , driver_id: nil, rider_id: nil, organization_id: nil)
+LocationRelationship.create(default: false, location_id: loc13.id , driver_id: nil, rider_id: nil, organization_id: nil)
+LocationRelationship.create(default: false, location_id: loc14.id , driver_id: nil, rider_id: nil, organization_id: nil)
+LocationRelationship.create(default: false, location_id: loc15.id , driver_id: nil, rider_id: nil, organization_id: nil)
 
 
-LocationRelationship.create(location_id: loc16.id , driver_id: driver2.id , rider_id: nil, organization_id: nil)
-LocationRelationship.create(location_id: loc17.id , driver_id: driver3.id , rider_id: nil, organization_id: nil)
-LocationRelationship.create(location_id: loc18.id , driver_id: driver3.id , rider_id: nil, organization_id: nil)
-LocationRelationship.create(location_id: loc19.id , driver_id: driver3.id , rider_id: nil, organization_id: nil)
-LocationRelationship.create(location_id: loc10.id , driver_id: driver4.id , rider_id: nil, organization_id: nil)
+
+
+LocationRelationship.create(default: false, location_id: loc16.id , driver_id: driver2.id , rider_id: nil, organization_id: nil)
+LocationRelationship.create(default: false, location_id: loc17.id , driver_id: driver3.id , rider_id: nil, organization_id: nil)
+LocationRelationship.create(default: false, location_id: loc18.id , driver_id: driver3.id , rider_id: nil, organization_id: nil)
+LocationRelationship.create(default: true, location_id: loc19.id , driver_id: driver3.id , rider_id: nil, organization_id: nil)
+LocationRelationship.create(default: false, location_id: loc10.id , driver_id: driver4.id , rider_id: nil, organization_id: nil)
 
 
 

--- a/spec/factories/location_relationships.rb
+++ b/spec/factories/location_relationships.rb
@@ -1,4 +1,5 @@
 FactoryBot.define do
    factory :location_relationship do
+     default { true }
    end
 end

--- a/spec/features/drivers/drivers_spec.rb
+++ b/spec/features/drivers/drivers_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature 'Drivers', type: :feature, js: true do
   let!(:driver_outside_organization) { create :driver, email: 'adriver@gmail.com', first_name: 'Jerry' }
   let!(:location) { create :location, street: '201 W Main st', city: 'Durham', state: 'NC', zip: '27701' }
   let!(:location1) { create :location, street: "400 Main St", city: 'Durham', state: "NC", zip: "27713" }
-  let!(:location_relationship) { create :location_relationship, driver_id: driver.id, location_id: location.id }
+  let!(:location_relationship) { create :location_relationship, driver_id: driver.id, location_id: location.id, default: true }
   let!(:vehicle1) { create :vehicle, driver_id: driver.id }
   let!(:schedule_window) { create :schedule_window, driver_id: driver.id, location_id: location.id }
   let!(:schedule_window1) { create :schedule_window, driver_id: driver.id, location_id: location1.id }

--- a/spec/requests/drivers_spec.rb
+++ b/spec/requests/drivers_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Api::V1::Drivers, type: :request do
     let!(:driver2) { FactoryBot.create(:driver, first_name: "Phil", organization_id: organization.id,
     auth_token: "5678", token_created_at: Time.zone.now) }
     let!(:location) { FactoryBot.create(:location) }
-    let!(:location_relationships) { LocationRelationship.create(driver_id: driver.id, location_id: location.id) }
+    let!(:location_relationships) { LocationRelationship.create(driver_id: driver.id, location_id: location.id, default: true) }
 
     it 'Test password reset' do
     post '/api/v1/drivers/password_reset',

--- a/spec/requests/locations_spec.rb
+++ b/spec/requests/locations_spec.rb
@@ -13,9 +13,9 @@ RSpec.describe Api::V1::Locations, type: :request do
   #To test locations I needed to create some locations and also some relationships
   let!(:location){FactoryBot.create(:location)}
   let!(:location2){FactoryBot.create(:location, street: "1202 W Dublin St", city: "Chandler", state: "Az", zip: "85224")}
-  let!(:locationrelationship){LocationRelationship.create(driver_id: driver.id, location_id: location.id)}
-  let!(:locationrelationship2){LocationRelationship.create(driver_id: driver.id, location_id: location2.id)}
-  let!(:locationrelationship3){LocationRelationship.create(driver_id: driver2.id, location_id: location2.id)}
+  let!(:locationrelationship){LocationRelationship.create(driver_id: driver.id, location_id: location.id, default: true)}
+  let!(:locationrelationship2){LocationRelationship.create(driver_id: driver.id, location_id: location2.id, default: false)}
+  let!(:locationrelationship3){LocationRelationship.create(driver_id: driver2.id, location_id: location2.id, default: true)}
 
 
 
@@ -27,7 +27,10 @@ RSpec.describe Api::V1::Locations, type: :request do
                 { street:"200 W Front St",
                   city:"Burlington",
                   state:"NC",
-                  zip: "27215"}}
+                  zip: "27215"},
+                default_location: {
+                  default: true
+                  }}
       expect(response).to have_http_status(201)
       parsed_json = JSON.parse(response.body)
       expect(parsed_json['location']['street']).to eq('200 W Front St')
@@ -92,11 +95,19 @@ RSpec.describe Api::V1::Locations, type: :request do
   end
 
   it 'returns a new address when a location is shared by two drivers but update by one driver' do
+    location_relationship = LocationRelationship.where(location: location2.id).first
+    # location_relationship.update(default: params[:default_location][:default], location: new_location)
       put "/api/v1/locations/#{location2.id}", headers: {"ACCEPT" => "application/json",  "Token" => "5678" },
       params: { location: { street:"1052 Canal St",
                             city:"Durham",
                             state:"NC",
-                            zip: "27701"}}
+                            zip: "27701"
+                          },
+        location_relationship: {
+          default: true,
+          location: location.id
+        }}
+
       expect(response).to have_http_status(200)
       #uncomment these to see the error messages
       # parsed_json = JSON.parse(response.body)


### PR DESCRIPTION
- Calculated and added distance from drivers' default location to the pick-up location on rides endpoint.
- Add a check that a driver can have only one default address
- Fix bugs on locations update endpoint
- Fix failing tests
@jrmcgarvey @micronix 

Thank you!