### PR TITLE
Add riders info on ride endpoints

### DIFF
--- a/app/serializers/ride_serializer.rb
+++ b/app/serializers/ride_serializer.rb
@@ -1,6 +1,6 @@
 class RideSerializer < ActiveModel::Serializer
   ActiveModelSerializers.config.adapter = :json
-  attributes :id, :organization_id, :rider_id, :driver_id, :pick_up_time, :start_location, :end_location,  :reason, :status, :completed_at, :round_trip, :expected_wait_time,
+  attributes :id, :organization_id, :driver_id, :pick_up_time, :rider, :start_location, :end_location,  :reason, :status, :completed_at, :round_trip, :expected_wait_time,
   :pickup_to_dropoff_distance, :pickup_to_dropoff_time, :default_to_pickup_distance
 
   def default_to_pickup_distance
@@ -13,6 +13,16 @@ class RideSerializer < ActiveModel::Serializer
     else
       return nil
     end
+  end
+
+  def rider
+    rider = Rider.find(object.rider_id)
+    {
+      first_name: rider.first_name,
+      last_name: rider.last_name,
+      phone: rider.phone,
+      note: rider.notes
+    }
   end
 
 end

--- a/spec/requests/riders_spec.rb
+++ b/spec/requests/riders_spec.rb
@@ -6,28 +6,26 @@ RSpec.describe "Api::V1::Riders", type: :request do
     let!(:rider) {FactoryBot.create(:rider, organization_id: organization.id) }
     let!(:rider1) {FactoryBot.create(:rider, organization_id: organization.id, email: "a1@.com") }
     let!(:rider2) {FactoryBot.create(:rider, organization_id: organization.id, email: "stuff@mail.com") }
-    
-   it "returns all riders" do
+
+   xit "returns all riders" do
     get '/api/v1/riders', headers: {"ACCEPT" => "application/json" }
     expect(response).to have_http_status(201)
    end
-   
-   it "returns a 404 error when there nothing to retrive" do
+
+   xit "returns a 404 error when there nothing to retrive" do
     Rider.destroy_all
     get '/api/v1/riders', headers: {"ACCEPT" => "application/json" }
     expect(response).to have_http_status(404)
    end
-    
+
 # This test Return a rider with a given ID
-  it "returns rider ID" do
+  xit "returns rider ID" do
     get "/api/v1/riders/#{rider.id}", headers: {"ACCEPT" => "application/json" }
     expect(response).to have_http_status(201)
   end
-  
-  it "returns a 404 error when id can not be found" do
+
+  xit "returns a 404 error when id can not be found" do
     get "/api/v1/riders/#{102319}", headers: {"ACCEPT" => "application/json" }
     expect(response).to have_http_status(404)
   end
 end
-
- 


### PR DESCRIPTION
- Added riders’ `first_name`, `last_name`, `phone`, and `notes` on `ride` endpoints
- Skipped riders' `request` test suite since the endpoint is taken down temporarily

Thanks @jrmcgarvey !