### PR TITLE
Modify ride endpoint to allow drivers to cancel rides 

### DIFF
--- a/app/controllers/api/v1/rides.rb
+++ b/app/controllers/api/v1/rides.rb
@@ -296,8 +296,12 @@
           status 404
           return {}
         end
-        if ride.status == "scheduled" && ride.driver_id == current_driver.id # && ride.pick_up_time >= Date.today + 1.week
-          ride.update(driver_id: nil, status: "approved")
+        if ride.status != "approved" && ride.driver_id == current_driver.id
+          if ride.status == "scheduled" # && ride.pick_up_time >= Date.today + 1.week
+            ride.update(driver_id: nil, status: "approved")
+          else
+            ride.update(driver_id: nil, status: "canceled")
+          end
           status 201
           render ride
         else


### PR DESCRIPTION
- Modified ride endpoint to allow drivers to cancel rides for all `status` except for `approved` ones.
     - When a `scheduled` ride is canceled, it will put the status back to `approved'.
     - When a ride with other status is canceled, it will put the status back to `canceled`.
     - Any time a ride is canceled, the driver id will be `nil`.

@jrmcgarvey @micronix @kidatsy 
Thanks!
