### PR TITLE
Nullify round trip references

### DIFF
--- a/app/controllers/api/v1/rides.rb
+++ b/app/controllers/api/v1/rides.rb
@@ -164,7 +164,7 @@
         end
         #driver can only have one ride in a active state
         if current_driver.rides.where( status: "picking-up" || "dropping-off" ||
-           "waiting" || "return-picking-up" || "return-dropping-off")
+           "waiting" || "return-picking-up" || "return-dropping-off").count > 0
           status 400
           return { error: "Sorry, there's a ride already in progress." }
         end

--- a/app/models/ride.rb
+++ b/app/models/ride.rb
@@ -6,6 +6,8 @@ class Ride < ApplicationRecord
   belongs_to :rider
   belongs_to :start_location, :class_name => "Location"
   belongs_to :end_location, :class_name => "Location"
+  has_one :outbound_ride, class_name: 'Ride', foreign_key: :outbound, dependent: :nullify
+  has_one :inbound_ride, class_name: 'Ride', foreign_key: :return, dependent: :nullify
   has_one :token
 
   validates :start_location, :end_location, :pick_up_time, :reason, :status, presence: true

--- a/spec/requests/admin_rides_controllers_spec.rb
+++ b/spec/requests/admin_rides_controllers_spec.rb
@@ -207,7 +207,7 @@ RSpec.describe AdminRideController, type: :request do
             }
           }
         end.not_to change(Ride, :count)
-      expect(flash[:alert]).to eq ("Return time must be at least 30 minutes after departure time")
+      expect(response.body).to include("Return time must be at least 30 minutes after departure time")
       expect(response.redirect?).to eq(false)
       expect(response).to render_template(:new)
     end
@@ -236,7 +236,7 @@ RSpec.describe AdminRideController, type: :request do
             }
           }
         end.not_to change(Ride, :count)
-      expect(flash[:alert]).to eq ("Return time must be at least 30 minutes after departure time")
+      expect(response.body).to include("Return time must be at least 30 minutes after departure time")
       expect(response.redirect?).to eq(false)
       expect(response).to render_template(:new)
     end
@@ -265,7 +265,7 @@ RSpec.describe AdminRideController, type: :request do
             }
           }
         end.to change(Ride, :count)
-        expect(flash[:alert]).to match("Start location and end location can not be the same")
+        expect(response.body).to include("Start location and end location can not be the same")
         expect(response.redirect?).to eq(false)
       end
 
@@ -553,7 +553,7 @@ RSpec.describe AdminRideController, type: :request do
             }
           }
         end.to change(Ride, :count)
-        expect(flash[:alert]).to match("Start location and end location can not be the same")
+        expect(response.body).to include("Start location and end location can not be the same")
         expect(response.redirect?).to eq(false)
       end
 


### PR DESCRIPTION
## Description
Nullify the references from the round trip when any part of the trip is deleted.

What does the PR do?
This PR makes the `outbound` and `return` nil for round trip when a part of the trip is removed.

## Background Information

## Screenshots
<img width="1206" alt="Screen Shot 2021-02-09 at 2 58 39 PM" src="https://user-images.githubusercontent.com/25111094/107421393-e6f90080-6ae7-11eb-92c3-bc80c513207b.png">

## Checklist:
- [x] Screenshots attached (if dealing with UI)
- [ ] Unit Tests (if applicable)

## Testing Steps for reviewer:
- Step 1
- Step 2
Thanks @micronix @jrmcgarvey @kidatsy !!