### PR TITLE
Display all the rides in the the rides menu 

### DIFF
--- a/app/views/admin_ride/index.html.erb
+++ b/app/views/admin_ride/index.html.erb
@@ -13,7 +13,7 @@
           Status
       </a>
       <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-        <%= link_to 'Show all rides', admin_ride_index_path %>
+        <%= link_to 'All rides', admin_ride_index_path %>
         <%= link_to 'Pending', admin_ride_index_path(status: "pending") %>
         <%= link_to 'Approved', admin_ride_index_path(status: "approved") %>
         <%= link_to 'Scheduled', admin_ride_index_path(status: "scheduled") %>


### PR DESCRIPTION
## Description
Initially, we had been showing only the current rides in the rides menu and not the rides that were in the past

What does the PR do?
This PR shows all the rides in the rides menu whether it is in the past or current. Also, added the `All rides` option in the dropdown filter of rides.

## Background Information
Doug reported that he was not able to see the history of the completed rides that were in the past since we had applied the time constraint to the list of rides

## Screenshots
<img width="1153" alt="Screen Shot 2021-03-12 at 11 38 48 AM" src="https://user-images.githubusercontent.com/25111094/110971946-797c0200-8329-11eb-9340-3a2c1e236bef.png">

<img width="1133" alt="Screen Shot 2021-03-12 at 11 39 20 AM" src="https://user-images.githubusercontent.com/25111094/110971978-7da81f80-8329-11eb-89f7-73106fcd7775.png">

## Checklist:
- [x] Screenshots attached (if dealing with UI)
- [ ] Unit Tests (if applicable)

## Testing Steps for reviewer:
- Step 1
- Step 2
Thanks @jrmcgarvey @micronix @kidatsy 