### PR TITLE
Add a new returning home rides endpoint

### DIFF
--- a/app/controllers/api/v1/rides.rb
+++ b/app/controllers/api/v1/rides.rb
@@ -149,6 +149,30 @@
         end
       end
 
+      # Driver Acceting only an approved ride with new API "scheduled"
+      desc "Accept a ride"
+      params do
+       requires :ride_id, type: String, desc: "ID of the ride"
+      end
+      post "rides/:ride_id/scheduled" do
+       begin
+         ride = Ride.find(permitted_params[:ride_id])
+       rescue ActiveRecord::RecordNotFound
+         status 404
+         return {}
+       end
+
+       unless ride.driver_id.nil? && ride.status == "approved"
+         status 401
+         return { error: 'Not Authorized'}
+       end
+
+       if ride.update(driver_id: current_driver.id, status: "scheduled")
+         RiderMailer.ride_accepted_notifications(ride).deliver_later
+         status 201
+         render ride
+       end
+      end
 
       # Driver picking up riders only with scheduled rides
       desc "Picking up a rider"

--- a/app/controllers/api/v1/rides.rb
+++ b/app/controllers/api/v1/rides.rb
@@ -124,7 +124,7 @@
         end
       end
 
-      # Driver Acceting only an approved ride with old API "accept"
+      # Driver Acceting only an approved ride
       desc "Accept a ride"
       params do
         requires :ride_id, type: String, desc: "ID of the ride"
@@ -148,31 +148,6 @@
           render ride
         end
       end
-
-       # Driver Acceting only an approved ride with new API "scheduled"
-       desc "Accept a ride"
-       params do
-         requires :ride_id, type: String, desc: "ID of the ride"
-       end
-       post "rides/:ride_id/scheduled" do
-         begin
-           ride = Ride.find(permitted_params[:ride_id])
-         rescue ActiveRecord::RecordNotFound
-           status 404
-           return {}
-         end
- 
-         unless ride.driver_id.nil? && ride.status == "approved"
-           status 401
-           return { error: 'Not Authorized'}
-         end
- 
-         if ride.update(driver_id: current_driver.id, status: "scheduled")
-           RiderMailer.ride_accepted_notifications(ride).deliver_later
-           status 201
-           render ride
-         end
-       end
 
 
       # Driver picking up riders only with scheduled rides
@@ -225,6 +200,28 @@
         end
       end
 
+      # Driver returning-home after dropping-off a rider
+      desc "Returning home after dropping off a rider"
+      params do
+        requires :ride_id, type: String, desc: "ID of the ride"
+      end
+      post "rides/:ride_id/returning-home" do
+        begin
+          ride = Ride.find(permitted_params[:ride_id])
+        rescue ActiveRecord::RecordNotFound
+          status 404
+          return {}
+        end
+        if ride.status == "dropping-off" && ride.driver_id == current_driver.id
+          ride.update_attribute(:status, "returning-home")
+          status 201
+          render ride
+        else
+          status 401
+          return { error: "Not Authorized" }
+        end
+      end
+
       # Driver waiting a rider after dropping-off
       desc "Waiting a rider after dropping off"
       params do
@@ -237,7 +234,7 @@
           status 404
           return {}
         end
-        if ride.status == "dropping-off" && ride.driver_id == current_driver.id
+        if ride.status == "returning-home" && ride.driver_id == current_driver.id
           ride.update_attribute(:status, "waiting")
           status 201
           render ride
@@ -303,7 +300,7 @@
           status 404
         return {}
         end
-        if ["dropping-off", "return-dropping-off"].include?(ride.status) && ride.driver_id == current_driver.id
+        if ride.status == "returning-home" && ride.driver_id == current_driver.id
           ride.update_attributes(status: "completed", completed_at: Time.now)
           status 201
           render ride

--- a/app/models/ride.rb
+++ b/app/models/ride.rb
@@ -16,7 +16,7 @@ class Ride < ApplicationRecord
   validates :start_location, :end_location, :pick_up_time, :reason, :status, presence: true
   validate :pick_up_time_cannot_be_in_the_past
   # validate :valid_locations
-  validates :status, inclusion: { in: %w(pending approved scheduled picking-up dropping-off waiting return-picking-up return-dropping-off completed canceled),
+  validates :status, inclusion: { in: %w(pending approved scheduled picking-up dropping-off returning-home waiting return-picking-up return-dropping-off completed canceled),
   message: "%{value} is not a valid status" }
   # validates :expected_wait_time, presence: true, if: :round_trip?
   after_validation :set_distance, on: [ :create, :update ]


### PR DESCRIPTION
## Description
Add a new `returning-home` endpoint to account for the time/distance that the driver spent

What does the PR do?
This PR allows the drivers to transit from `dropping-off` status to `returning-home`

## Background Information
Seymour Center needed to account the time driver spends on each ride 

## Screenshots
<img width="970" alt="Screen Shot 2021-03-12 at 3 13 26 PM" src="https://user-images.githubusercontent.com/25111094/110993857-dbe2fb80-8345-11eb-823d-55f134b3ebd5.png">

## Checklist:
- [x] Screenshots attached (if dealing with UI)
- [ ] Unit Tests (if applicable)

## Testing Steps for reviewer:
- Step 1
- Step 2
Thanks @micronix @jrmcgarvey @kidatsy 